### PR TITLE
Add fail closed provenance trust and privacy safe live ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ The full specification of record is
 | Crate | Description |
 |-------|-------------|
 | [`rufield-core`](crates/rufield-core) | Data model + traits: `Modality` (15), `FieldAxis`, `FieldTensor`, `PrivacyClass` (P0–P5), `FieldEvent`, `Observation`, `CalibrationReceipt`, `FieldInference`, and the `FieldAdapter`/`FieldEncoder`/`FusionEngine`/`PrivacyGuard` traits. |
-| [`rufield-provenance`](crates/rufield-provenance) | Real `sha256` content hashing + `ed25519` sign/verify, and the §11 fusability invariant (`is_fusable`). |
+| [`rufield-provenance`](crates/rufield-provenance) | Real `sha256` content hashing + `ed25519` sign/verify. ADR-261 adds explicit simulation, captured-replay, and production trust policies, an independently enrolled sensor-key registry, revocation, freshness checks, and persistent replay watermarks. The legacy `is_fusable` helper is simulation-only. |
 | [`rufield-privacy`](crates/rufield-privacy) | `PrivacyClass` policy + `DefaultPrivacyGuard`: P0 edge-only, network ≤ P2, P4 consent gate, P5 identity binding. |
 | [`rufield-adapters`](crates/rufield-adapters) | Deterministic seeded `SyntheticSim` adapter (camera-free room-intelligence demo across 3 modalities) **plus `CsiReplayAdapter`** — the first real (non-synthetic) adapter, replaying real captured WiFi CSI from a `.csi.jsonl` recording (replay, unlabeled). |
 | [`rufield-fusion`](crates/rufield-fusion) | `FusionGraph` + `RuFieldFusion` engine with TOML rules (weighted-Bayes / temporal-window), confidence + expiry. |
 | [`rufield-bench`](crates/rufield-bench) | Deterministic benchmark runner: F1 per task (SYNTHETIC), p95 latency, provenance coverage, privacy violations, and the ADR-260 §31 acceptance test. |
-| [`rufield-viewer`](crates/rufield-viewer) | Read-only web dashboard (Axum + vanilla JS, no build step): room state, event log with privacy badges, fusion graph, signed-receipt viewer. **Two sources** — `--source synthetic` (default) replays `SyntheticSim → RuFieldFusion`; `--source live --upstream <URL>` ingests **real** `FieldEvent`s from a RuField upstream (RuView `/ws/field` / `/api/field`, ADR-262 P3), verifying each receipt on ingest. Honest, mutually-exclusive `SYNTHETIC` / `LIVE` / `DISCONNECTED` banner. Not a device-management console. |
+| [`rufield-viewer`](crates/rufield-viewer) | Read-only web dashboard (Axum + vanilla JS, no build step): room state, event log with privacy badges, fusion graph, and a synthetic-mode signed-receipt viewer. **Two sources** — `--source synthetic` (default) replays `SyntheticSim → RuFieldFusion`; `--source live --upstream <URL>` ingests **real** `FieldEvent`s over the RuView `/ws/field` / `/api/field` transport (ADR-262 P3). Live startup requires an independently enrolled sensor-key registry and an ADR-261 production or captured-replay policy. Live SSE uses a fail-closed public projection with stable trust diagnostics and no event/device/zone ids, raw labels, hashes, signer keys, signatures, model ids, or provenance edges. Honest, mutually-exclusive `SYNTHETIC` / `LIVE` / `DISCONNECTED` banner. Not a device-management console. |
 
 ## Install / Quickstart
 
@@ -110,7 +110,7 @@ Endpoints: `GET /` (page), `GET /events` (Server-Sent Events stream),
 `GET /api/run` (full deterministic run as JSON), `GET /api/source` (the
 data-source selector + banner state), `GET /health`.
 
-### Live mode — consume a real RuField feed (ADR-262 P3)
+### Live mode — ADR-261 trust over the ADR-262 P3 transport
 
 The same dashboard can display **real** `FieldEvent`s streamed from an external
 upstream (RuView's `wifi-densepose-sensing-server`, which exposes `GET /api/field`
@@ -120,29 +120,50 @@ and `GET /ws/field` per ADR-262 P3) instead of the built-in synthetic simulator:
 # Default: SYNTHETIC (simulator replay)
 cargo run -p rufield-viewer -- --source synthetic
 
-# LIVE: ingest a real RuField upstream
-cargo run -p rufield-viewer -- --source live --upstream http://127.0.0.1:8080
+# LIVE: replace SENSOR_PUBLIC_KEY_HEX with the independently enrolled key
+cargo run -p rufield-viewer -- --source live \
+  --upstream http://127.0.0.1:8080 \
+  --sensor-key sensor_room_01=SENSOR_PUBLIC_KEY_HEX
 ```
 
 Env equivalents: `RUFIELD_VIEWER_SOURCE` (`synthetic`|`live`),
-`RUFIELD_VIEWER_UPSTREAM`, `RUFIELD_VIEWER_POLL_MS`. **The default stays
+`RUFIELD_VIEWER_UPSTREAM`, `RUFIELD_VIEWER_POLL_MS`,
+`RUFIELD_VIEWER_SENSOR_KEYS` (comma-separated `sensor=key` bindings), and
+`RUFIELD_VIEWER_TRUST_MODE` (`production` by default, or `captured_replay`).
+Production freshness can be tightened with `RUFIELD_VIEWER_MAX_EVENT_AGE_MS`
+and `RUFIELD_VIEWER_MAX_FUTURE_SKEW_MS`. **The source default stays
 SYNTHETIC.**
 
 In live mode the viewer subscribes to the upstream's `/ws/field` SSE stream
-(falling back to polling `/api/field`), **verifies each event's provenance
-receipt on ingest** (`rufield_provenance::is_fusable`), and runs the verified
-events through the *same* fusion/inference display path. The dashboard panels
-(room state / privacy badges / fusion graph / receipt modal) are identical — only
-the data source changes. Each event shows a per-event verified ✓/✗ badge;
-**unverified (forged/tampered) events are flagged and never fused into trusted
-inferences.**
+(falling back to polling `/api/field`) and authorizes every event through a
+persistent `TrustVerifier` before fusion state can change. The trust registry
+must be provisioned independently from the event stream. Production and
+captured-replay modes both reject synthetic events, unknown self-signed keys,
+revoked keys, sensor/key binding mismatches, malformed signatures, and replay;
+production additionally enforces stale/future timestamp bounds. Rejected
+events are flagged and never fused. The same `LiveProcessor` and replay
+watermarks survive upstream batches and reconnects within the running process.
+
+Before a live frame enters the broadcast channel, the default network privacy
+guard builds a redacted public projection. It never emits upstream event,
+device, or zone identifiers; observation labels; receipt hashes; signer keys;
+signatures; model or calibration identifiers; or supporting-event edges.
+Rejected events remain operationally visible through stable, non-identifying
+reason codes such as `unknown_key` or `signature_verification_failed`. P0, P3,
+P4, and P5 details are withheld by default; P4 requires consent and P5 requires
+identity binding before any future policy could release them.
+
+The reference viewer binary can accept restored replay state programmatically,
+but it does not yet atomically persist updated watermarks. A process restart
+therefore requires an operator-provided integrity-protected persistence adapter
+to retain replay rejection across restarts.
 
 > **Banner honesty (non-negotiable):** the banner reflects *exactly* what is being
 > shown, and the three states are mutually exclusive and visually distinct:
 >
 > - **`SYNTHETIC — simulated sensors, no hardware`** (amber) — synthetic mode.
 > - **`LIVE — <upstream>`** (green) — live mode, actually receiving
->   receipt-verified upstream events.
+>   policy-authorized upstream events.
 > - **`DISCONNECTED — <upstream> unreachable`** (red) — live mode selected but the
 >   upstream cannot be reached. The viewer shows this explicitly and **never**
 >   falls back to synthetic data under a LIVE banner (or vice versa).
@@ -178,10 +199,10 @@ use rufield_provenance::is_fusable;
 let config = SimConfig { seed: 2026, ..SimConfig::default() };
 let events = run_demo(&config);
 
-// 2. Feed events into the fusion engine; it rejects any non-fusable event.
+// 2. This deterministic demo deliberately uses the simulation-only policy.
 let mut engine = RuFieldFusion::new();
 for se in &events {
-    assert!(is_fusable(&se.event)); // §11 invariant: receipt OR synthetic
+    assert!(is_fusable(&se.event)); // compatibility helper: simulation only
     engine.ingest(se.event.clone()).unwrap();
 }
 
@@ -219,9 +240,10 @@ emits a signed `FieldEvent` per frame — which feeds the same `RuFieldFusion`
 engine as the synthetic stream.
 
 ```rust
-use rufield_adapters::CsiReplayAdapter;
+use rufield_adapters::{CsiReplayAdapter, REPLAY_SIGNER_SEED};
 use rufield_core::{FieldAdapter, FusionEngine, InferenceQuery};
 use rufield_fusion::RuFieldFusion;
+use rufield_provenance::{Signer, TrustPolicy, TrustVerifier, TrustedKeyRegistry};
 
 // Real captured WiFi CSI, replayed from a recording file (not live hardware).
 let jsonl = std::fs::read_to_string("recording.csi.jsonl")?;
@@ -231,11 +253,16 @@ let mut adapter = CsiReplayAdapter::from_jsonl(&jsonl)?;
 let receipt = adapter.calibrate("living_room")?;
 println!("calibration: {} ({})", receipt.calibration_id, receipt.data_hash);
 
-// Stream events through the fusion engine. Each event carries a REAL sha256
-// over the raw subcarrier bytes + a real ed25519 signature (replay key).
-let mut engine = RuFieldFusion::new();
+// Configure captured-replay trust independently from incoming events. This
+// fixture key is deterministic; production deployments provision keys through
+// an authenticated control plane instead.
+let signer = Signer::from_seed(&REPLAY_SIGNER_SEED);
+let mut registry = TrustedKeyRegistry::new();
+registry.enroll_sensor_key("csi_replay_node_01", &signer.public_hex())?;
+let trust = TrustVerifier::new(TrustPolicy::captured_replay(), registry);
+let mut engine = RuFieldFusion::with_trust_verifier(trust);
 while let Some(event) = adapter.next_event()? {
-    engine.ingest(event)?;          // §11: verified receipt, not the synthetic hatch
+    engine.ingest(event)?;
     for inf in engine.infer(&InferenceQuery::all())? {
         println!("{} conf={:.2} privacy={:?}", inf.label, inf.confidence, inf.privacy_class);
     }
@@ -365,10 +392,16 @@ audit log**.
 > **No fused inference is valid unless every contributing event has a
 > provenance receipt or is explicitly marked synthetic.**
 
-`rufield-provenance` enforces this with real `sha256` content hashing and
-`ed25519` signatures. `is_fusable(&event)` returns true iff the event is
-flagged `synthetic` **or** carries a signature that verifies. Tampering with
-any field after signing makes verification (and fusability) fail.
+`rufield-provenance` enforces integrity with real `sha256` content hashing and
+`ed25519` signatures. The compatibility helper `is_fusable(&event)` implements
+the original rule only for simulation: it accepts an explicitly synthetic
+event or a signature that verifies against the event-carried key.
+
+Captured replay and production use the ADR-261 stateful `TrustVerifier`
+instead. Those modes reject synthetic evidence and require a key enrolled and
+bound to the sensor independently of the event. They also enforce revocation
+and monotonic replay watermarks; production adds stale/future time bounds. All
+checks pass before either replay or fusion state is mutated.
 
 ## Spec / ADR
 

--- a/crates/rufield-fusion/src/engine.rs
+++ b/crates/rufield-fusion/src/engine.rs
@@ -3,13 +3,15 @@
 //! Ingests [`FieldEvent`]s, maintains a short temporal window of recent
 //! per-modality derived features, applies the TOML [`RuleSet`], and produces
 //! [`FieldInference`]s with supporting/contradicting events, confidence decay,
-//! and `expires_at`. Events that fail the §11 fusability invariant are rejected.
+//! and `expires_at`. Ingestion runs through a stateful provenance trust policy
+//! before any event reaches the fusion window or graph.
 
 use crate::graph::{EdgeKind, FusionGraph, NodeKind};
 use crate::rules::{Method, Rule, RuleSet};
 use rufield_core::{FieldEvent, FieldInference, FusionEngine, InferenceQuery, PrivacyClass};
-use rufield_provenance::is_fusable;
+use rufield_provenance::{TrustError, TrustMode, TrustPolicy, TrustVerifier, TrustedKeyRegistry};
 use std::collections::VecDeque;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// How long an inference stays valid after production (ns). 2 seconds.
 const INFERENCE_TTL_NS: u64 = 2_000_000_000;
@@ -20,23 +22,37 @@ const WINDOW: usize = 8;
 /// Errors from the fusion engine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FusionError {
-    /// An event failed the §11 fusability invariant (no receipt, not synthetic).
+    /// An event failed the legacy simulation fusability invariant.
     NotFusable(String),
+    /// Captured replay or production policy rejected an event.
+    TrustRejected {
+        /// Rejected event id.
+        event_id: String,
+        /// Machine-readable trust-policy reason.
+        reason: TrustError,
+    },
 }
 
 impl std::fmt::Display for FusionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FusionError::NotFusable(id) => {
-                write!(
-                    f,
-                    "event {id} is not fusable (no verified receipt and not synthetic)"
-                )
+                write!(f, "event {id} is not fusable in simulation mode")
+            }
+            FusionError::TrustRejected { event_id, reason } => {
+                write!(f, "event {event_id} rejected by trust policy: {reason}")
             }
         }
     }
 }
-impl std::error::Error for FusionError {}
+impl std::error::Error for FusionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TrustRejected { reason, .. } => Some(reason),
+            Self::NotFusable(_) => None,
+        }
+    }
+}
 
 /// A retained event with its key derived features.
 #[derive(Debug, Clone)]
@@ -55,33 +71,115 @@ struct WindowItem {
 /// The default RuField fusion engine.
 pub struct RuFieldFusion {
     rules: RuleSet,
+    trust: TrustVerifier,
     window: VecDeque<WindowItem>,
     graph: FusionGraph,
     last_ts_ns: u64,
 }
 
 impl RuFieldFusion {
-    /// Construct with the default room-state rule set.
+    /// Construct the backwards-compatible deterministic simulation engine.
+    ///
+    /// Live callers must instead construct a production [`TrustVerifier`] and
+    /// pass it to [`Self::with_trust_verifier`].
     #[must_use]
     pub fn new() -> Self {
         RuFieldFusion::with_rules(RuleSet::default_room_state())
     }
 
-    /// Construct with a custom rule set.
+    /// Construct with custom rules in explicit simulation mode.
     #[must_use]
     pub fn with_rules(rules: RuleSet) -> Self {
+        Self::with_rules_and_trust(rules, TrustVerifier::simulation())
+    }
+
+    /// Construct with default rules and an explicit trust policy.
+    #[must_use]
+    pub fn with_trust_verifier(trust: TrustVerifier) -> Self {
+        Self::with_rules_and_trust(RuleSet::default_room_state(), trust)
+    }
+
+    /// Construct a fail-closed live engine from independently enrolled keys.
+    #[must_use]
+    pub fn production(registry: TrustedKeyRegistry) -> Self {
+        Self::with_trust_verifier(TrustVerifier::new(TrustPolicy::production(), registry))
+    }
+
+    /// Construct with custom rules and an explicit trust policy.
+    #[must_use]
+    pub fn with_rules_and_trust(rules: RuleSet, trust: TrustVerifier) -> Self {
         RuFieldFusion {
             rules,
+            trust,
             window: VecDeque::new(),
             graph: FusionGraph::new(),
             last_ts_ns: 0,
         }
     }
 
+    /// Read-only access to policy, enrollment and replay state.
+    #[must_use]
+    pub const fn trust_verifier(&self) -> &TrustVerifier {
+        &self.trust
+    }
+
+    /// Mutable access for protected enrollment, revocation and replay-state
+    /// restoration before ingestion starts.
+    #[must_use]
+    pub fn trust_verifier_mut(&mut self) -> &mut TrustVerifier {
+        &mut self.trust
+    }
+
     /// Read-only view of the fusion graph.
     #[must_use]
     pub fn graph(&self) -> &FusionGraph {
         &self.graph
+    }
+
+    /// Ingest using an explicit wall-clock value. This is the deterministic
+    /// entry point for production tests and replay orchestration.
+    pub fn ingest_at(&mut self, event: FieldEvent, now_ns: u64) -> Result<(), FusionError> {
+        let event_id = event.event_id.clone();
+        let mode = self.trust.mode();
+        if let Err(reason) = self.trust.verify_and_record_at(&event, now_ns) {
+            return if mode == TrustMode::Simulation {
+                Err(FusionError::NotFusable(event_id))
+            } else {
+                Err(FusionError::TrustRejected { event_id, reason })
+            };
+        }
+        self.commit_verified_event(event);
+        Ok(())
+    }
+
+    fn commit_verified_event(&mut self, event: FieldEvent) {
+        let f = &event.observation.features;
+        let item = WindowItem {
+            event_id: event.event_id.clone(),
+            modality: event.sensor.modality.clone(),
+            timestamp_ns: event.timestamp_ns,
+            motion_energy: *f.get("motion_energy").unwrap_or(&0.0),
+            breathing_band: *f.get("breathing_band").unwrap_or(&0.0),
+            posture_height: *f.get("posture_height").unwrap_or(&0.0),
+            transient: *f.get("transient").unwrap_or(&0.0),
+            range_m: *f.get("range_m").unwrap_or(&0.0),
+            presence: *f.get("presence").unwrap_or(&0.0),
+        };
+
+        self.graph
+            .add_node(&event.sensor.device_id, NodeKind::Sensor);
+        self.graph.add_node(&event.event_id, NodeKind::Event);
+        self.graph.add_edge(
+            &event.event_id,
+            &event.sensor.device_id,
+            EdgeKind::ObservedBy,
+        );
+
+        self.last_ts_ns = event.timestamp_ns;
+        self.window.push_back(item);
+        while self.window.len() > WINDOW * 3 {
+            self.window.pop_front();
+        }
     }
 
     fn feat(&self, item: &WindowItem, key: &str) -> f32 {
@@ -205,41 +303,11 @@ impl FusionEngine for RuFieldFusion {
     type Error = FusionError;
 
     fn ingest(&mut self, event: FieldEvent) -> Result<(), Self::Error> {
-        // §11 invariant: reject non-fusable events.
-        if !is_fusable(&event) {
-            return Err(FusionError::NotFusable(event.event_id.clone()));
-        }
-
-        let f = &event.observation.features;
-        let item = WindowItem {
-            event_id: event.event_id.clone(),
-            modality: event.sensor.modality.clone(),
-            timestamp_ns: event.timestamp_ns,
-            motion_energy: *f.get("motion_energy").unwrap_or(&0.0),
-            breathing_band: *f.get("breathing_band").unwrap_or(&0.0),
-            posture_height: *f.get("posture_height").unwrap_or(&0.0),
-            transient: *f.get("transient").unwrap_or(&0.0),
-            range_m: *f.get("range_m").unwrap_or(&0.0),
-            presence: *f.get("presence").unwrap_or(&0.0),
-        };
-
-        // Record provenance in the graph.
-        self.graph
-            .add_node(&event.sensor.device_id, NodeKind::Sensor);
-        self.graph.add_node(&event.event_id, NodeKind::Event);
-        self.graph.add_edge(
-            &event.event_id,
-            &event.sensor.device_id,
-            EdgeKind::ObservedBy,
-        );
-
-        self.last_ts_ns = event.timestamp_ns;
-        self.window.push_back(item);
-        // Keep window bounded per overall stream (3 modalities × WINDOW ticks).
-        while self.window.len() > WINDOW * 3 {
-            self.window.pop_front();
-        }
-        Ok(())
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX))
+            .unwrap_or(0);
+        self.ingest_at(event, now_ns)
     }
 
     fn infer(&self, query: &InferenceQuery) -> Result<Vec<FieldInference>, Self::Error> {
@@ -279,6 +347,7 @@ impl FusionEngine for RuFieldFusion {
 mod tests {
     use super::*;
     use rufield_adapters::{run_demo, SimConfig};
+    use rufield_provenance::Signer;
 
     #[test]
     fn rejects_non_fusable_event() {
@@ -295,6 +364,100 @@ mod tests {
         let mut engine = RuFieldFusion::new();
         let err = engine.ingest(ev).unwrap_err();
         assert!(matches!(err, FusionError::NotFusable(_)));
+    }
+
+    #[test]
+    fn production_rejection_cannot_mutate_graph_or_replay_watermark() {
+        let cfg = SimConfig {
+            seed: 2,
+            ..SimConfig::default()
+        };
+        let mut event = run_demo(&cfg).remove(0).event;
+        event.provenance.synthetic = false;
+        let signer = Signer::from_seed(&[21; 32]);
+        signer.sign_event(&mut event).unwrap();
+
+        let mut engine = RuFieldFusion::production(TrustedKeyRegistry::new());
+        let timestamp_ns = event.timestamp_ns;
+        let error = engine.ingest_at(event, timestamp_ns).unwrap_err();
+        assert!(matches!(
+            error,
+            FusionError::TrustRejected {
+                reason: TrustError::UnknownKey,
+                ..
+            }
+        ));
+        assert_eq!(engine.graph().node_count(), 0);
+        assert!(engine
+            .trust_verifier()
+            .export_replay_state()
+            .watermarks
+            .is_empty());
+    }
+
+    #[test]
+    fn production_acceptance_mutates_graph_only_after_trust() {
+        let cfg = SimConfig {
+            seed: 3,
+            ..SimConfig::default()
+        };
+        let mut event = run_demo(&cfg).remove(0).event;
+        event.provenance.synthetic = false;
+        let signer = Signer::from_seed(&[22; 32]);
+        signer.sign_event(&mut event).unwrap();
+
+        let mut registry = TrustedKeyRegistry::new();
+        registry
+            .enroll_sensor_key(&event.sensor.device_id, signer.public_hex())
+            .unwrap();
+        let timestamp_ns = event.timestamp_ns;
+        let mut engine = RuFieldFusion::production(registry);
+        engine.ingest_at(event, timestamp_ns).unwrap();
+
+        assert_eq!(engine.graph().node_count(), 2);
+        assert_eq!(
+            engine
+                .trust_verifier()
+                .export_replay_state()
+                .watermarks
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn empty_event_id_cannot_mutate_graph_or_replay_watermark() {
+        let cfg = SimConfig {
+            seed: 4,
+            ..SimConfig::default()
+        };
+        let mut event = run_demo(&cfg).remove(0).event;
+        event.event_id.clear();
+        event.provenance.synthetic = false;
+        let signer = Signer::from_seed(&[23; 32]);
+        signer.sign_event(&mut event).unwrap();
+
+        let mut registry = TrustedKeyRegistry::new();
+        registry
+            .enroll_sensor_key(&event.sensor.device_id, signer.public_hex())
+            .unwrap();
+        let timestamp_ns = event.timestamp_ns;
+        let mut engine = RuFieldFusion::production(registry);
+        let error = engine.ingest_at(event, timestamp_ns).unwrap_err();
+
+        assert!(matches!(
+            error,
+            FusionError::TrustRejected {
+                reason: TrustError::MalformedIdentity(_),
+                ..
+            }
+        ));
+        assert_eq!(engine.graph().node_count(), 0);
+        assert!(engine
+            .trust_verifier()
+            .export_replay_state()
+            .watermarks
+            .is_empty());
     }
 
     #[test]

--- a/crates/rufield-fusion/src/lib.rs
+++ b/crates/rufield-fusion/src/lib.rs
@@ -6,8 +6,10 @@
 //! a TOML [`RuleSet`] (weighted-Bayes and temporal-window methods) over a short
 //! per-modality temporal window, and produces [`FieldInference`](rufield_core::FieldInference)s
 //! with supporting/contradicting events, privacy class, calibration/model id,
-//! and an expiry time. Events that fail the §11 fusability invariant (no
-//! verified receipt and not synthetic) are rejected at ingest.
+//! and an expiry time. Every event passes through an explicit stateful trust
+//! policy before it reaches the fusion graph. [`RuFieldFusion::new`] is scoped
+//! to backwards-compatible simulation; live ingestion must supply a production
+//! [`rufield_provenance::TrustVerifier`].
 
 #![doc(html_root_url = "https://docs.rs/rufield-fusion/0.1.0")]
 

--- a/crates/rufield-provenance/src/lib.rs
+++ b/crates/rufield-provenance/src/lib.rs
@@ -1,12 +1,16 @@
 //! # rufield-provenance
 //!
-//! Provenance receipts for RuField MFS (ADR-260 §11). Provides real
-//! `sha256` hashing of feature / firmware / model / calibration material and
-//! `ed25519` detached signatures over [`FieldEvent`]s, plus the §11
-//! fusability invariant:
+//! Provenance receipts and policy verification for RuField MFS (ADR-260 §11).
+//! Provides real `sha256` hashing of feature / firmware / model / calibration
+//! material and `ed25519` detached signatures over [`FieldEvent`]s.
 //!
 //! > No fused inference is valid unless every contributing event has a
 //! > provenance receipt **or** is explicitly marked synthetic.
+//!
+//! That original invariant is retained by [`is_fusable`] for deterministic
+//! simulation compatibility only. Captured replay and production ingestion
+//! must use [`TrustVerifier`], which anchors event keys in an independently
+//! configured [`TrustedKeyRegistry`] and enforces replay protection.
 //!
 //! Signing is **deterministic**: ed25519 (RFC 8032) produces the same
 //! signature for the same key + message, and [`Signer`] derives its key
@@ -19,6 +23,13 @@
 use ed25519_dalek::{Signature, Signer as _, SigningKey, Verifier as _, VerifyingKey};
 use rufield_core::FieldEvent;
 use sha2::{Digest, Sha256};
+
+mod trust;
+
+pub use trust::{
+    ReplayState, ReplayWatermark, TrustError, TrustMode, TrustPolicy, TrustVerifier,
+    TrustedKeyRegistry, DEFAULT_MAX_EVENT_AGE_NS, DEFAULT_MAX_FUTURE_SKEW_NS, REPLAY_STATE_VERSION,
+};
 
 /// Compute a `sha256:<hex>` digest over arbitrary bytes (firmware image, raw
 /// measurement, model weights, calibration data).
@@ -97,16 +108,34 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 fn hex_decode(s: &str) -> Result<Vec<u8>, ProvenanceError> {
-    if !s.len().is_multiple_of(2) {
+    let bytes = s.as_bytes();
+    if !bytes.is_ascii() {
+        return Err(ProvenanceError::BadEncoding(
+            "hex input must contain ASCII characters only".into(),
+        ));
+    }
+    if !bytes.len().is_multiple_of(2) {
         return Err(ProvenanceError::BadEncoding("odd hex length".into()));
     }
-    (0..s.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&s[i..i + 2], 16)
-                .map_err(|e| ProvenanceError::BadEncoding(e.to_string()))
+    bytes
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = hex_nibble(pair[0])?;
+            let low = hex_nibble(pair[1])?;
+            Ok((high << 4) | low)
         })
         .collect()
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, ProvenanceError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(ProvenanceError::BadEncoding(format!(
+            "invalid hex character 0x{byte:02x}"
+        ))),
+    }
 }
 
 /// A deterministic ed25519 signer derived from a 32-byte seed.
@@ -173,8 +202,13 @@ pub fn verify_event(event: &FieldEvent) -> Result<(), ProvenanceError> {
         .map_err(|_| ProvenanceError::VerifyFailed)
 }
 
-/// The §11 fusability invariant. An event may be fused into an inference iff it
-/// is explicitly marked `synthetic` **or** it carries a signature that verifies.
+/// Legacy §11 fusability helper for simulation and compatibility tooling.
+///
+/// This function verifies cryptographic integrity against the public key
+/// carried by the event itself. It does **not** establish that the signer is a
+/// trusted sensor, enforce sensor-to-key binding, check freshness or reject
+/// replay. Never use it as a production authorization decision. Use
+/// [`TrustVerifier::verify_and_record_at`] instead.
 #[must_use]
 pub fn is_fusable(event: &FieldEvent) -> bool {
     if event.provenance.synthetic {
@@ -226,6 +260,32 @@ mod tests {
                 signer_pubkey_hex: None,
             },
         )
+    }
+
+    #[test]
+    fn non_ascii_public_key_is_rejected_without_panicking() {
+        let signer = Signer::from_seed(&[41; 32]);
+        let mut event = sample_event();
+        signer.sign_event(&mut event).unwrap();
+        event.provenance.signer_pubkey_hex = Some("€".repeat(22));
+
+        assert!(matches!(
+            verify_event(&event),
+            Err(ProvenanceError::BadEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn non_ascii_signature_is_rejected_without_panicking() {
+        let signer = Signer::from_seed(&[42; 32]);
+        let mut event = sample_event();
+        signer.sign_event(&mut event).unwrap();
+        event.provenance.signature_hex = Some("€".repeat(44));
+
+        assert!(matches!(
+            verify_event(&event),
+            Err(ProvenanceError::BadEncoding(_))
+        ));
     }
 
     #[test]

--- a/crates/rufield-provenance/src/trust.rs
+++ b/crates/rufield-provenance/src/trust.rs
@@ -1,0 +1,920 @@
+//! Policy verification above the detached-signature primitive.
+//!
+//! The event-carried public key is treated as an identifier only. Captured
+//! replay and production modes authorize it against an independently
+//! configured trust registry before accepting the event.
+
+use super::{hex_decode, is_fusable, verify_event, ProvenanceError};
+use ed25519_dalek::VerifyingKey;
+use rufield_core::FieldEvent;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Current serialized replay-state schema.
+pub const REPLAY_STATE_VERSION: u16 = 1;
+
+/// Default production event age: five minutes.
+pub const DEFAULT_MAX_EVENT_AGE_NS: u64 = 300_000_000_000;
+
+/// Default production future-clock tolerance: five seconds.
+pub const DEFAULT_MAX_FUTURE_SKEW_NS: u64 = 5_000_000_000;
+
+/// Verification context. The modes deliberately have different trust rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustMode {
+    /// Deterministic tests and simulators. This is the only mode that accepts
+    /// unsigned synthetic evidence or event-carried self-signed keys.
+    Simulation,
+    /// Historical, real captured evidence. Requires enrolled keys, binding and
+    /// replay checks, but intentionally skips wall-clock freshness.
+    CapturedReplay,
+    /// Live evidence. Requires enrolled keys, binding, freshness and replay
+    /// checks and always rejects synthetic evidence.
+    Production,
+}
+
+/// Serializable policy parameters for a verifier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustPolicy {
+    /// Operational verification context.
+    pub mode: TrustMode,
+    /// Maximum accepted age in production.
+    pub max_event_age_ns: u64,
+    /// Maximum accepted positive clock skew in production.
+    pub max_future_skew_ns: u64,
+}
+
+impl TrustPolicy {
+    /// Policy preserving the original deterministic simulation behavior.
+    #[must_use]
+    pub const fn simulation() -> Self {
+        Self {
+            mode: TrustMode::Simulation,
+            max_event_age_ns: 0,
+            max_future_skew_ns: 0,
+        }
+    }
+
+    /// Policy for an authenticated historical capture.
+    #[must_use]
+    pub const fn captured_replay() -> Self {
+        Self {
+            mode: TrustMode::CapturedReplay,
+            max_event_age_ns: 0,
+            max_future_skew_ns: 0,
+        }
+    }
+
+    /// Default live policy with a five-minute age limit and five-second future
+    /// clock tolerance.
+    #[must_use]
+    pub const fn production() -> Self {
+        Self::production_with_window(DEFAULT_MAX_EVENT_AGE_NS, DEFAULT_MAX_FUTURE_SKEW_NS)
+    }
+
+    /// Live policy with caller-selected freshness limits.
+    #[must_use]
+    pub const fn production_with_window(max_event_age_ns: u64, max_future_skew_ns: u64) -> Self {
+        Self {
+            mode: TrustMode::Production,
+            max_event_age_ns,
+            max_future_skew_ns,
+        }
+    }
+}
+
+/// Independently provisioned sensor identity bindings and revocations.
+///
+/// This object is configuration, not event input. Persist it in a protected
+/// control-plane store in production.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TrustedKeyRegistry {
+    sensor_keys: BTreeMap<String, String>,
+    revoked_keys: BTreeSet<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TrustedKeyRegistryWire {
+    sensor_keys: BTreeMap<String, String>,
+    revoked_keys: BTreeSet<String>,
+}
+
+impl<'de> Deserialize<'de> for TrustedKeyRegistry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = TrustedKeyRegistryWire::deserialize(deserializer)?;
+        let mut registry = Self::new();
+
+        for (sensor_id, public_key_hex) in wire.sensor_keys {
+            let sensor_id =
+                normalize_sensor_id(&sensor_id).map_err(<D::Error as serde::de::Error>::custom)?;
+            let public_key_hex = normalize_public_key(&public_key_hex)
+                .map_err(<D::Error as serde::de::Error>::custom)?;
+            if registry
+                .sensor_keys
+                .insert(sensor_id.clone(), public_key_hex)
+                .is_some()
+            {
+                return Err(<D::Error as serde::de::Error>::custom(format!(
+                    "duplicate sensor id after normalization: {sensor_id}"
+                )));
+            }
+        }
+
+        for public_key_hex in wire.revoked_keys {
+            let public_key_hex = normalize_public_key(&public_key_hex)
+                .map_err(<D::Error as serde::de::Error>::custom)?;
+            registry.revoked_keys.insert(public_key_hex);
+        }
+
+        Ok(registry)
+    }
+}
+
+impl TrustedKeyRegistry {
+    /// Create an empty, fail-closed registry.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            sensor_keys: BTreeMap::new(),
+            revoked_keys: BTreeSet::new(),
+        }
+    }
+
+    /// Enroll or explicitly rotate a sensor to a valid Ed25519 public key.
+    pub fn enroll_sensor_key(
+        &mut self,
+        sensor_id: impl Into<String>,
+        public_key_hex: impl AsRef<str>,
+    ) -> Result<(), TrustError> {
+        let sensor_id = normalize_sensor_id(&sensor_id.into())?;
+        let public_key_hex = normalize_public_key(public_key_hex.as_ref())?;
+        self.sensor_keys.insert(sensor_id, public_key_hex);
+        Ok(())
+    }
+
+    /// Revoke a valid public key. Revocation wins over any existing binding.
+    pub fn revoke_key(&mut self, public_key_hex: impl AsRef<str>) -> Result<(), TrustError> {
+        let key = normalize_public_key(public_key_hex.as_ref())?;
+        self.revoked_keys.insert(key);
+        Ok(())
+    }
+
+    /// Remove a revocation after an explicit control-plane decision.
+    pub fn unrevoke_key(&mut self, public_key_hex: impl AsRef<str>) -> Result<(), TrustError> {
+        let key = normalize_public_key(public_key_hex.as_ref())?;
+        self.revoked_keys.remove(&key);
+        Ok(())
+    }
+
+    /// Return the enrolled key for a sensor.
+    #[must_use]
+    pub fn key_for_sensor(&self, sensor_id: &str) -> Option<&str> {
+        self.sensor_keys.get(sensor_id).map(String::as_str)
+    }
+
+    /// True when this key appears in at least one independently enrolled
+    /// sensor binding.
+    #[must_use]
+    pub fn contains_key(&self, public_key_hex: &str) -> bool {
+        self.sensor_keys
+            .values()
+            .any(|enrolled| enrolled == public_key_hex)
+    }
+
+    /// True when the key is explicitly revoked.
+    #[must_use]
+    pub fn is_revoked(&self, public_key_hex: &str) -> bool {
+        self.revoked_keys.contains(public_key_hex)
+    }
+
+    /// Number of independently enrolled sensor identities.
+    #[must_use]
+    pub fn sensor_count(&self) -> usize {
+        self.sensor_keys.len()
+    }
+
+    /// True when no sensor identity is enrolled.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.sensor_keys.is_empty()
+    }
+}
+
+/// Last accepted event for one sensor stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayWatermark {
+    /// Strictly increasing capture timestamp.
+    pub last_timestamp_ns: u64,
+    /// Last accepted event id, used to classify exact duplicates.
+    pub last_event_id: String,
+    /// Trusted signer responsible for the last accepted event.
+    pub signer_pubkey_hex: Option<String>,
+}
+
+/// Persistable replay defense state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayState {
+    /// Schema version for safe restoration.
+    pub version: u16,
+    /// Per-sensor strictly monotonic watermark.
+    pub watermarks: BTreeMap<String, ReplayWatermark>,
+}
+
+impl Default for ReplayState {
+    fn default() -> Self {
+        Self {
+            version: REPLAY_STATE_VERSION,
+            watermarks: BTreeMap::new(),
+        }
+    }
+}
+
+impl ReplayState {
+    /// Serialize for durable, integrity-protected storage.
+    pub fn to_json(&self) -> Result<String, TrustError> {
+        validate_replay_state(self)?;
+        serde_json::to_string(self).map_err(|error| TrustError::ReplayState(error.to_string()))
+    }
+
+    /// Deserialize and validate the replay-state schema.
+    pub fn from_json(json: &str) -> Result<Self, TrustError> {
+        let state: Self = serde_json::from_str(json)
+            .map_err(|error| TrustError::ReplayState(error.to_string()))?;
+        validate_replay_state(&state)?;
+        Ok(state)
+    }
+}
+
+/// Policy rejection reason. Callers can map these variants to metrics without
+/// parsing display strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustError {
+    /// An event or sensor identity was empty or otherwise malformed.
+    MalformedIdentity(String),
+    /// Synthetic evidence was presented outside simulation.
+    SyntheticRejected,
+    /// No public key was carried by an event that requires one.
+    MissingPublicKey,
+    /// The event-carried key has no independent enrollment.
+    UnknownKey,
+    /// No identity binding exists for the sensor id.
+    UnknownSensor(String),
+    /// The sensor is enrolled to a different key.
+    SensorKeyMismatch(String),
+    /// The independently known key is revoked.
+    RevokedKey,
+    /// The timestamp is older than the production freshness window.
+    StaleTimestamp,
+    /// The timestamp exceeds the allowed positive clock skew.
+    FutureTimestamp,
+    /// The exact last accepted event was submitted again.
+    DuplicateEvent(String),
+    /// The event timestamp did not strictly increase for its sensor.
+    NonMonotonicReplay {
+        /// Persisted last accepted timestamp.
+        last_timestamp_ns: u64,
+        /// Rejected timestamp.
+        event_timestamp_ns: u64,
+    },
+    /// Detached-signature validation failed.
+    Provenance(ProvenanceError),
+    /// Trust registry material was invalid.
+    InvalidRegistry(String),
+    /// Replay state was malformed, incompatible or attempted a rollback.
+    ReplayState(String),
+}
+
+impl std::fmt::Display for TrustError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MalformedIdentity(message) => write!(f, "malformed identity: {message}"),
+            Self::SyntheticRejected => write!(f, "synthetic evidence rejected by trust mode"),
+            Self::MissingPublicKey => write!(f, "event is missing signer public key"),
+            Self::UnknownKey => write!(f, "signer key is not independently enrolled"),
+            Self::UnknownSensor(sensor) => write!(f, "sensor {sensor} is not enrolled"),
+            Self::SensorKeyMismatch(sensor) => {
+                write!(f, "sensor {sensor} is enrolled to a different key")
+            }
+            Self::RevokedKey => write!(f, "signer key is revoked"),
+            Self::StaleTimestamp => write!(f, "event timestamp is stale"),
+            Self::FutureTimestamp => write!(f, "event timestamp is too far in the future"),
+            Self::DuplicateEvent(id) => write!(f, "duplicate event {id}"),
+            Self::NonMonotonicReplay {
+                last_timestamp_ns,
+                event_timestamp_ns,
+            } => write!(
+                f,
+                "event timestamp {event_timestamp_ns} is not newer than watermark {last_timestamp_ns}"
+            ),
+            Self::Provenance(error) => write!(f, "provenance rejected: {error}"),
+            Self::InvalidRegistry(message) => write!(f, "invalid trust registry: {message}"),
+            Self::ReplayState(message) => write!(f, "invalid replay state: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for TrustError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Provenance(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<ProvenanceError> for TrustError {
+    fn from(error: ProvenanceError) -> Self {
+        Self::Provenance(error)
+    }
+}
+
+/// Stateful policy verifier. A successful decision atomically advances the
+/// in-memory replay watermark. Every rejection leaves replay state unchanged.
+#[derive(Debug, Clone)]
+pub struct TrustVerifier {
+    policy: TrustPolicy,
+    registry: TrustedKeyRegistry,
+    replay: ReplayState,
+}
+
+impl TrustVerifier {
+    /// Construct from explicit policy and independently provisioned keys.
+    #[must_use]
+    pub fn new(policy: TrustPolicy, registry: TrustedKeyRegistry) -> Self {
+        Self {
+            policy,
+            registry,
+            replay: ReplayState::default(),
+        }
+    }
+
+    /// Compatibility verifier for deterministic simulator flows.
+    #[must_use]
+    pub fn simulation() -> Self {
+        Self::new(TrustPolicy::simulation(), TrustedKeyRegistry::new())
+    }
+
+    /// Current operational mode.
+    #[must_use]
+    pub const fn mode(&self) -> TrustMode {
+        self.policy.mode
+    }
+
+    /// Read policy parameters.
+    #[must_use]
+    pub const fn policy(&self) -> &TrustPolicy {
+        &self.policy
+    }
+
+    /// Read the independently configured registry.
+    #[must_use]
+    pub const fn registry(&self) -> &TrustedKeyRegistry {
+        &self.registry
+    }
+
+    /// Mutate enrollment or revocation through a protected control plane.
+    #[must_use]
+    pub fn registry_mut(&mut self) -> &mut TrustedKeyRegistry {
+        &mut self.registry
+    }
+
+    /// Export replay watermarks for durable storage before shutdown.
+    #[must_use]
+    pub fn export_replay_state(&self) -> ReplayState {
+        self.replay.clone()
+    }
+
+    /// Restore replay watermarks. Restoring may add or advance watermarks but
+    /// cannot remove or roll back any state already held by this verifier.
+    pub fn restore_replay_state(&mut self, state: ReplayState) -> Result<(), TrustError> {
+        validate_replay_state(&state)?;
+        for (sensor, current) in &self.replay.watermarks {
+            let incoming = state.watermarks.get(sensor).ok_or_else(|| {
+                TrustError::ReplayState(format!(
+                    "restore would remove watermark for sensor {sensor}"
+                ))
+            })?;
+            if incoming.last_timestamp_ns < current.last_timestamp_ns {
+                return Err(TrustError::ReplayState(format!(
+                    "restore would roll back sensor {sensor}"
+                )));
+            }
+        }
+        self.replay = state;
+        Ok(())
+    }
+
+    /// Verify an event against policy at an explicit wall-clock time, then
+    /// advance its sensor replay watermark.
+    ///
+    /// The watermark mutation is intentionally the final operation. Signature,
+    /// trust anchor, binding, revocation, freshness and replay checks all run
+    /// first, so malformed input cannot consume a valid sequence position.
+    pub fn verify_and_record_at(
+        &mut self,
+        event: &FieldEvent,
+        now_ns: u64,
+    ) -> Result<(), TrustError> {
+        validate_event_identity(event)?;
+        let signer = self.verify_without_replay(event, now_ns)?;
+        self.check_replay(event)?;
+
+        self.replay.watermarks.insert(
+            event.sensor.device_id.clone(),
+            ReplayWatermark {
+                last_timestamp_ns: event.timestamp_ns,
+                last_event_id: event.event_id.clone(),
+                signer_pubkey_hex: signer,
+            },
+        );
+        Ok(())
+    }
+
+    fn verify_without_replay(
+        &self,
+        event: &FieldEvent,
+        now_ns: u64,
+    ) -> Result<Option<String>, TrustError> {
+        if self.policy.mode == TrustMode::Simulation {
+            return if is_fusable(event) {
+                Ok(event
+                    .provenance
+                    .signer_pubkey_hex
+                    .as_deref()
+                    .map(str::to_ascii_lowercase))
+            } else {
+                Err(TrustError::Provenance(ProvenanceError::VerifyFailed))
+            };
+        }
+
+        if event.provenance.synthetic {
+            return Err(TrustError::SyntheticRejected);
+        }
+
+        let carried_key = event
+            .provenance
+            .signer_pubkey_hex
+            .as_deref()
+            .ok_or(TrustError::MissingPublicKey)?;
+        let carried_key = normalize_public_key(carried_key)?;
+
+        if self.registry.is_revoked(&carried_key) {
+            return Err(TrustError::RevokedKey);
+        }
+        if !self.registry.contains_key(&carried_key) {
+            return Err(TrustError::UnknownKey);
+        }
+        let enrolled_key = self
+            .registry
+            .key_for_sensor(&event.sensor.device_id)
+            .ok_or_else(|| TrustError::UnknownSensor(event.sensor.device_id.clone()))?;
+        if enrolled_key != carried_key {
+            return Err(TrustError::SensorKeyMismatch(
+                event.sensor.device_id.clone(),
+            ));
+        }
+
+        verify_event(event)?;
+
+        if self.policy.mode == TrustMode::Production {
+            if event.timestamp_ns > now_ns.saturating_add(self.policy.max_future_skew_ns) {
+                return Err(TrustError::FutureTimestamp);
+            }
+            if now_ns
+                > event
+                    .timestamp_ns
+                    .saturating_add(self.policy.max_event_age_ns)
+            {
+                return Err(TrustError::StaleTimestamp);
+            }
+        }
+
+        Ok(Some(carried_key))
+    }
+
+    fn check_replay(&self, event: &FieldEvent) -> Result<(), TrustError> {
+        let Some(watermark) = self.replay.watermarks.get(&event.sensor.device_id) else {
+            return Ok(());
+        };
+        if event.event_id == watermark.last_event_id {
+            return Err(TrustError::DuplicateEvent(event.event_id.clone()));
+        }
+        if event.timestamp_ns <= watermark.last_timestamp_ns {
+            return Err(TrustError::NonMonotonicReplay {
+                last_timestamp_ns: watermark.last_timestamp_ns,
+                event_timestamp_ns: event.timestamp_ns,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn normalize_public_key(public_key_hex: &str) -> Result<String, TrustError> {
+    let bytes = hex_decode(public_key_hex)?;
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| TrustError::InvalidRegistry("Ed25519 public key must be 32 bytes".into()))?;
+    VerifyingKey::from_bytes(&bytes)
+        .map_err(|error| TrustError::InvalidRegistry(error.to_string()))?;
+    Ok(public_key_hex.to_ascii_lowercase())
+}
+
+fn normalize_sensor_id(sensor_id: &str) -> Result<String, TrustError> {
+    let sensor_id = sensor_id.trim();
+    if sensor_id.is_empty() {
+        return Err(TrustError::InvalidRegistry(
+            "sensor id must not be empty".into(),
+        ));
+    }
+    if sensor_id.chars().any(char::is_control) {
+        return Err(TrustError::InvalidRegistry(
+            "sensor id must not contain control characters".into(),
+        ));
+    }
+    Ok(sensor_id.to_owned())
+}
+
+fn validate_event_identity(event: &FieldEvent) -> Result<(), TrustError> {
+    if event.event_id.trim().is_empty() {
+        return Err(TrustError::MalformedIdentity(
+            "event id must not be empty".into(),
+        ));
+    }
+    if event.sensor.device_id.trim().is_empty() {
+        return Err(TrustError::MalformedIdentity(
+            "sensor id must not be empty".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_replay_state(state: &ReplayState) -> Result<(), TrustError> {
+    if state.version != REPLAY_STATE_VERSION {
+        return Err(TrustError::ReplayState(format!(
+            "unsupported version {}; expected {REPLAY_STATE_VERSION}",
+            state.version
+        )));
+    }
+    if state
+        .watermarks
+        .keys()
+        .any(|sensor| sensor.trim().is_empty())
+    {
+        return Err(TrustError::ReplayState(
+            "sensor ids in replay state must not be empty".into(),
+        ));
+    }
+    for (sensor, watermark) in &state.watermarks {
+        if watermark.last_event_id.trim().is_empty() {
+            return Err(TrustError::ReplayState(format!(
+                "last event id for sensor {sensor} must not be empty"
+            )));
+        }
+        if let Some(key) = &watermark.signer_pubkey_hex {
+            normalize_public_key(key).map_err(|error| {
+                TrustError::ReplayState(format!(
+                    "signer key for sensor {sensor} is malformed: {error}"
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{sha256_hex, Signer};
+    use rufield_core::{
+        FieldAxis, FieldTensor, Modality, Observation, PrivacyClass, ProvenanceRef,
+        SensorDescriptor,
+    };
+
+    const NOW_NS: u64 = 1_800_000_000_000_000_000;
+
+    fn sample_event(id: &str, timestamp_ns: u64, sensor_id: &str) -> FieldEvent {
+        let tensor = FieldTensor::new(
+            timestamp_ns,
+            Modality::WifiCsi,
+            vec![FieldAxis::Frequency],
+            vec![3],
+            vec![1.0, 2.0, 3.0],
+            0.9,
+            0.01,
+            Some("cal".into()),
+            PrivacyClass::P2,
+        )
+        .unwrap();
+        FieldEvent::new(
+            id,
+            timestamp_ns,
+            SensorDescriptor {
+                modality: "wifi_csi".into(),
+                vendor: "esp32_c6".into(),
+                device_id: sensor_id.into(),
+                placement: "corner".into(),
+                clock_domain: "ptp".into(),
+            },
+            tensor,
+            Observation::occupancy(0.9, PrivacyClass::P2),
+            ProvenanceRef {
+                raw_hash: sha256_hex(b"raw"),
+                firmware_hash: sha256_hex(b"fw"),
+                model_id: "m1".into(),
+                calibration_id: "cal".into(),
+                synthetic: false,
+                signature_hex: None,
+                signer_pubkey_hex: None,
+            },
+        )
+    }
+
+    fn production_verifier(signer: &Signer, sensor_id: &str) -> TrustVerifier {
+        let mut registry = TrustedKeyRegistry::new();
+        registry
+            .enroll_sensor_key(sensor_id, signer.public_hex())
+            .unwrap();
+        TrustVerifier::new(TrustPolicy::production(), registry)
+    }
+
+    #[test]
+    fn production_accepts_trusted_bound_fresh_event() {
+        let signer = Signer::from_seed(&[1; 32]);
+        let mut event = sample_event("trusted", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        assert_eq!(verifier.verify_and_record_at(&event, NOW_NS), Ok(()));
+    }
+
+    #[test]
+    fn production_rejects_synthetic_flag_flip() {
+        let signer = Signer::from_seed(&[2; 32]);
+        let mut event = sample_event("flag-flip", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        event.provenance.synthetic = true;
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::SyntheticRejected)
+        );
+    }
+
+    #[test]
+    fn production_rejects_unknown_self_signed_key() {
+        let enrolled = Signer::from_seed(&[3; 32]);
+        let attacker = Signer::from_seed(&[4; 32]);
+        let mut event = sample_event("self-signed", NOW_NS, "sensor-a");
+        attacker.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&enrolled, "sensor-a");
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::UnknownKey)
+        );
+    }
+
+    #[test]
+    fn production_rejects_exact_duplicate() {
+        let signer = Signer::from_seed(&[5; 32]);
+        let mut event = sample_event("duplicate", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        verifier.verify_and_record_at(&event, NOW_NS).unwrap();
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::DuplicateEvent("duplicate".into()))
+        );
+    }
+
+    #[test]
+    fn production_rejects_nonmonotonic_replay() {
+        let signer = Signer::from_seed(&[6; 32]);
+        let mut newest = sample_event("newest", NOW_NS, "sensor-a");
+        let mut older = sample_event("older", NOW_NS - 1, "sensor-a");
+        signer.sign_event(&mut newest).unwrap();
+        signer.sign_event(&mut older).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        verifier.verify_and_record_at(&newest, NOW_NS).unwrap();
+        assert!(matches!(
+            verifier.verify_and_record_at(&older, NOW_NS),
+            Err(TrustError::NonMonotonicReplay { .. })
+        ));
+    }
+
+    #[test]
+    fn production_rejects_stale_event() {
+        let signer = Signer::from_seed(&[7; 32]);
+        let timestamp = NOW_NS - DEFAULT_MAX_EVENT_AGE_NS - 1;
+        let mut event = sample_event("stale", timestamp, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::StaleTimestamp)
+        );
+    }
+
+    #[test]
+    fn production_rejects_future_event() {
+        let signer = Signer::from_seed(&[8; 32]);
+        let timestamp = NOW_NS + DEFAULT_MAX_FUTURE_SKEW_NS + 1;
+        let mut event = sample_event("future", timestamp, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::FutureTimestamp)
+        );
+    }
+
+    #[test]
+    fn production_rejects_revoked_key() {
+        let signer = Signer::from_seed(&[9; 32]);
+        let mut event = sample_event("revoked", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        verifier
+            .registry_mut()
+            .revoke_key(signer.public_hex())
+            .unwrap();
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::RevokedKey)
+        );
+    }
+
+    #[test]
+    fn deserialized_uppercase_revocation_is_normalized_and_rejected() {
+        let signer = Signer::from_seed(&[31; 32]);
+        let public_key = signer.public_hex();
+        let json = serde_json::json!({
+            "sensor_keys": { " sensor-a ": public_key.clone() },
+            "revoked_keys": [public_key.to_ascii_uppercase()]
+        })
+        .to_string();
+        let registry: TrustedKeyRegistry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            registry.key_for_sensor("sensor-a"),
+            Some(public_key.as_str())
+        );
+        assert!(registry.is_revoked(&public_key));
+
+        let mut event = sample_event("uppercase-revocation", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = TrustVerifier::new(TrustPolicy::production(), registry);
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::RevokedKey)
+        );
+        assert!(verifier.export_replay_state().watermarks.is_empty());
+    }
+
+    #[test]
+    fn registry_deserialization_rejects_invalid_ids_and_keys() {
+        let signer = Signer::from_seed(&[32; 32]);
+        let valid_key = signer.public_hex();
+        let invalid_registries = [
+            serde_json::json!({
+                "sensor_keys": { "   ": valid_key.clone() },
+                "revoked_keys": []
+            }),
+            serde_json::json!({
+                "sensor_keys": { "sensor-a": "not-hex" },
+                "revoked_keys": []
+            }),
+            serde_json::json!({
+                "sensor_keys": { "sensor-a": valid_key.clone() },
+                "revoked_keys": ["not-hex"]
+            }),
+        ];
+
+        for invalid in invalid_registries {
+            assert!(serde_json::from_value::<TrustedKeyRegistry>(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn production_rejects_sensor_key_binding_mismatch() {
+        let signer_a = Signer::from_seed(&[10; 32]);
+        let signer_b = Signer::from_seed(&[11; 32]);
+        let mut registry = TrustedKeyRegistry::new();
+        registry
+            .enroll_sensor_key("sensor-a", signer_a.public_hex())
+            .unwrap();
+        registry
+            .enroll_sensor_key("sensor-b", signer_b.public_hex())
+            .unwrap();
+        let mut event = sample_event("mismatch", NOW_NS, "sensor-a");
+        signer_b.sign_event(&mut event).unwrap();
+        let mut verifier = TrustVerifier::new(TrustPolicy::production(), registry);
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::SensorKeyMismatch("sensor-a".into()))
+        );
+    }
+
+    #[test]
+    fn malformed_signature_does_not_advance_watermark() {
+        let signer = Signer::from_seed(&[12; 32]);
+        let mut event = sample_event("malformed", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        event.provenance.signature_hex = Some("not-hex".into());
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        let before = verifier.export_replay_state();
+        assert!(matches!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::Provenance(ProvenanceError::BadEncoding(_)))
+        ));
+        assert_eq!(verifier.export_replay_state(), before);
+    }
+
+    #[test]
+    fn empty_event_id_does_not_advance_watermark() {
+        let signer = Signer::from_seed(&[33; 32]);
+        let mut event = sample_event("", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut verifier = production_verifier(&signer, "sensor-a");
+        let before = verifier.export_replay_state();
+        assert_eq!(
+            verifier.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::MalformedIdentity(
+                "event id must not be empty".into()
+            ))
+        );
+        assert_eq!(verifier.export_replay_state(), before);
+    }
+
+    #[test]
+    fn replay_state_json_round_trip_rejects_replay_after_restart() {
+        let signer = Signer::from_seed(&[13; 32]);
+        let mut event = sample_event("before-restart", NOW_NS, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+
+        let mut first = production_verifier(&signer, "sensor-a");
+        first.verify_and_record_at(&event, NOW_NS).unwrap();
+        let json = first.export_replay_state().to_json().unwrap();
+        let restored = ReplayState::from_json(&json).unwrap();
+        assert_eq!(restored, first.export_replay_state());
+
+        let mut restarted = production_verifier(&signer, "sensor-a");
+        restarted.restore_replay_state(restored).unwrap();
+        assert_eq!(
+            restarted.verify_and_record_at(&event, NOW_NS),
+            Err(TrustError::DuplicateEvent("before-restart".into()))
+        );
+    }
+
+    #[test]
+    fn replay_state_rejects_empty_last_event_id() {
+        let mut state = ReplayState::default();
+        state.watermarks.insert(
+            "sensor-a".into(),
+            ReplayWatermark {
+                last_timestamp_ns: NOW_NS,
+                last_event_id: "".into(),
+                signer_pubkey_hex: None,
+            },
+        );
+        assert!(matches!(state.to_json(), Err(TrustError::ReplayState(_))));
+    }
+
+    #[test]
+    fn replay_state_rejects_malformed_signer_key() {
+        let json = format!(
+            r#"{{"version":{REPLAY_STATE_VERSION},"watermarks":{{"sensor-a":{{"last_timestamp_ns":{NOW_NS},"last_event_id":"event-a","signer_pubkey_hex":"not-hex"}}}}}}"#
+        );
+        assert!(matches!(
+            ReplayState::from_json(&json),
+            Err(TrustError::ReplayState(_))
+        ));
+    }
+
+    #[test]
+    fn captured_replay_accepts_old_trusted_event() {
+        let signer = Signer::from_seed(&[14; 32]);
+        let mut event = sample_event("capture", 1, "sensor-a");
+        signer.sign_event(&mut event).unwrap();
+        let mut registry = TrustedKeyRegistry::new();
+        registry
+            .enroll_sensor_key("sensor-a", signer.public_hex())
+            .unwrap();
+        let mut verifier = TrustVerifier::new(TrustPolicy::captured_replay(), registry);
+        assert_eq!(verifier.verify_and_record_at(&event, NOW_NS), Ok(()));
+    }
+
+    #[test]
+    fn simulation_is_only_unsigned_synthetic_escape_hatch() {
+        let mut event = sample_event("simulation", 1, "sim-a");
+        event.provenance.synthetic = true;
+        let mut verifier = TrustVerifier::simulation();
+        assert_eq!(verifier.verify_and_record_at(&event, NOW_NS), Ok(()));
+    }
+}

--- a/crates/rufield-viewer/src/lib.rs
+++ b/crates/rufield-viewer/src/lib.rs
@@ -10,12 +10,10 @@
 //!
 //! ## Honesty (non-negotiable)
 //!
-//! Everything this viewer shows is **SYNTHETIC** — produced by a deterministic
-//! simulator. There is **no hardware**, no live sensor, and no live camera.
-//! This is a *demo viewer*, not a device-management console: in v0.1 there are
-//! no real devices to manage. Fleet / real-adapter integration is a separate,
-//! later milestone. The dashboard renders a persistent
-//! `SYNTHETIC — simulated sensors, no hardware` banner that cannot be dismissed.
+//! Synthetic mode is the default and is always visibly labeled. Live mode is
+//! fail closed: it requires an independently injected sensor-key registry and
+//! a production or captured-replay trust policy before its ingest task starts.
+//! Live mode never falls back to simulation.
 //!
 //! ## What it serves
 //!
@@ -23,15 +21,16 @@
 //! - `GET /app.js`   — the vanilla-JS dashboard logic.
 //! - `GET /health`   — liveness JSON.
 //! - `GET /api/run`  — the full deterministic run as JSON (non-streaming).
-//! - `GET /events`   — Server-Sent Events: each tick frame + its inferences,
-//!   paced at a watchable cadence; loops or stops cleanly.
+//! - `GET /events`   — Server-Sent Events. Synthetic frames retain demo
+//!   receipts. Live frames are a privacy-guarded public projection with stable
+//!   trust diagnostics and no upstream direct identifiers or receipt material.
 //!
 //! ## Run it
 //!
 //! ```no_run
 //! # async fn run() {
 //! use rufield_viewer::{app, ViewerConfig};
-//! let router = app(ViewerConfig::default());
+//! let router = app(ViewerConfig::default()).unwrap();
 //! let listener = tokio::net::TcpListener::bind("127.0.0.1:8088").await.unwrap();
 //! axum::serve(listener, router).await.unwrap();
 //! # }
@@ -45,10 +44,14 @@ pub mod server;
 pub mod source;
 
 pub use live::{
-    frame_from_api_payload, frame_from_events, frame_from_ws_event, ApiFieldPayload, LiveFrame,
+    frame_from_api_payload, frame_from_events, frame_from_ws_event, ApiFieldPayload,
+    LiveEventDetails, LiveEventView, LiveFrame, LiveInferenceView, LivePrivacyDisposition,
+    LiveProcessor, LiveTickFrame, LiveTrustConfig, LiveTrustDecisionView, LiveTrustRejectionCode,
 };
 pub use runtime::{
     build_run, EventView, InferenceView, PrivacyBadge, ReceiptView, RunData, TickFrame,
 };
-pub use server::{app, app_no_ingest, AppState, ViewerConfig, DEFAULT_SEED, DEFAULT_TICK_MS};
+pub use server::{
+    app, app_no_ingest, AppState, ViewerConfig, ViewerConfigError, DEFAULT_SEED, DEFAULT_TICK_MS,
+};
 pub use source::{banner_for, BannerState, LiveState, SourceMode, DEFAULT_POLL_MS};

--- a/crates/rufield-viewer/src/live.rs
+++ b/crates/rufield-viewer/src/live.rs
@@ -1,4 +1,4 @@
-//! Live-ingest mode (ADR-260 §27.9 + ADR-262 P3).
+//! Live-ingest mode (ADR-260 §27.9 and ADR-261 trust policy).
 //!
 //! In `--source live` the viewer no longer replays the built-in `SyntheticSim`.
 //! Instead it consumes **real** `rufield_core::FieldEvent`s streamed from an
@@ -15,29 +15,180 @@
 //!
 //! ## Honesty & provenance (non-negotiable)
 //!
-//! Every ingested event is run through the **same** §11 fusability /
-//! provenance-receipt verification the synthetic path uses
-//! ([`rufield_provenance::is_fusable`] / [`rufield_provenance::verify_event`]).
-//! An event whose receipt does **not** verify is *flagged unverified* and is
-//! **never fused** — it is surfaced in the event log with a ✗ badge so forged
-//! data is visible but is not rendered as trusted, and it does not contribute to
-//! any room-state inference.
+//! Every ingested event is authorized by a persistent production or captured
+//! replay [`rufield_provenance::TrustVerifier`]. Live ingestion never calls the
+//! legacy stateless fusability helper and never creates a simulation fusion
+//! engine. A rejected event is surfaced as a redacted diagnostic with a stable
+//! reason code but cannot mutate replay, graph or inference-window state.
+//! Raw upstream events never enter the broadcast channel: a default network
+//! privacy guard creates a public projection that omits event, device and zone
+//! identifiers, observation labels, hashes, signer keys and signatures.
 //!
 //! This module deliberately splits **pure** ingest/render logic (no I/O — fully
 //! unit-testable by injecting a JSON payload) from the small HTTP client used at
 //! runtime. The pure path is [`frame_from_api_payload`] / [`frame_from_events`].
 
-use crate::runtime::{EventView, InferenceView, ReceiptView, TickFrame};
-use rufield_core::{FieldEvent, FusionEngine, InferenceQuery};
-use rufield_fusion::RuFieldFusion;
-use rufield_provenance::is_fusable;
+use crate::runtime::PrivacyBadge;
+use rufield_core::{
+    Destination, FieldEvent, FieldInference, FusionEngine, InferenceQuery, PrivacyDecision,
+    PrivacyGuard,
+};
+use rufield_fusion::{FusionError, RuFieldFusion};
+use rufield_privacy::DefaultPrivacyGuard;
+use rufield_provenance::{
+    ProvenanceError, ReplayState, TrustError, TrustMode, TrustPolicy, TrustVerifier,
+    TrustedKeyRegistry,
+};
 use serde::{Deserialize, Serialize};
+
+/// Explicit trust configuration injected at the live source boundary.
+#[derive(Debug, Clone)]
+pub struct LiveTrustConfig {
+    /// Production or captured-replay policy. Simulation is forbidden here.
+    pub policy: TrustPolicy,
+    /// Independently provisioned sensor-to-key bindings and revocations.
+    pub registry: TrustedKeyRegistry,
+    /// Optional replay watermark restored before ingest opens.
+    pub replay_state: Option<ReplayState>,
+}
+
+impl LiveTrustConfig {
+    /// Default live production trust configuration.
+    #[must_use]
+    pub fn production(registry: TrustedKeyRegistry) -> Self {
+        Self {
+            policy: TrustPolicy::production(),
+            registry,
+            replay_state: None,
+        }
+    }
+
+    /// Historical captured-replay trust configuration.
+    #[must_use]
+    pub fn captured_replay(registry: TrustedKeyRegistry) -> Self {
+        Self {
+            policy: TrustPolicy::captured_replay(),
+            registry,
+            replay_state: None,
+        }
+    }
+
+    /// Attach validated persisted replay state for restart protection.
+    #[must_use]
+    pub fn with_replay_state(mut self, replay_state: ReplayState) -> Self {
+        self.replay_state = Some(replay_state);
+        self
+    }
+
+    /// Build the stateful live processor. Simulation fails closed.
+    pub fn into_processor(self) -> Result<LiveProcessor, TrustError> {
+        LiveProcessor::new(self)
+    }
+}
+
+/// Stateful live authorization and fusion boundary.
+///
+/// One processor must be retained for the lifetime of a live source so replay
+/// watermarks and the temporal fusion window survive across batches.
+pub struct LiveProcessor {
+    engine: RuFieldFusion,
+    privacy_guard: DefaultPrivacyGuard,
+}
+
+impl LiveProcessor {
+    /// Build from explicit trust configuration.
+    pub fn new(config: LiveTrustConfig) -> Result<Self, TrustError> {
+        if config.policy.mode == TrustMode::Simulation {
+            return Err(TrustError::InvalidRegistry(
+                "simulation trust mode is forbidden for live ingestion".into(),
+            ));
+        }
+        if config.registry.is_empty() {
+            return Err(TrustError::InvalidRegistry(
+                "live ingestion requires at least one enrolled sensor key".into(),
+            ));
+        }
+        let mut verifier = TrustVerifier::new(config.policy, config.registry);
+        if let Some(state) = config.replay_state {
+            verifier.restore_replay_state(state)?;
+        }
+        Ok(Self {
+            engine: RuFieldFusion::with_trust_verifier(verifier),
+            privacy_guard: DefaultPrivacyGuard::default(),
+        })
+    }
+
+    /// Read-only fusion state for governance and tests.
+    #[must_use]
+    pub const fn fusion(&self) -> &RuFieldFusion {
+        &self.engine
+    }
+
+    fn process_events_at(&mut self, tick: usize, events: &[FieldEvent], now_ns: u64) -> LiveFrame {
+        let mut event_views = Vec::with_capacity(events.len());
+        let mut verified_count = 0usize;
+        let mut unverified_count = 0usize;
+        let mut privacy_redacted_count = 0usize;
+
+        for (sequence, event) in events.iter().enumerate() {
+            let trust = match self.engine.ingest_at(event.clone(), now_ns) {
+                Ok(()) => LiveTrustDecisionView {
+                    accepted: true,
+                    rejection_code: None,
+                },
+                Err(error) => LiveTrustDecisionView {
+                    accepted: false,
+                    rejection_code: Some(trust_rejection_code(&error)),
+                },
+            };
+            if trust.accepted {
+                verified_count += 1;
+            } else {
+                unverified_count += 1;
+            }
+            let event_view = public_event_view(event, sequence, trust, &self.privacy_guard);
+            if event_view.details.is_none() {
+                privacy_redacted_count += 1;
+            }
+            event_views.push(event_view);
+        }
+
+        let produced = self
+            .engine
+            .infer(&InferenceQuery::all())
+            .unwrap_or_default();
+        let mut privacy_redacted_inference_count = 0usize;
+        let inferences = produced
+            .iter()
+            .filter_map(|inference| {
+                if network_allowed(&self.privacy_guard, inference.privacy_class) {
+                    Some(LiveInferenceView::from(inference))
+                } else {
+                    privacy_redacted_inference_count += 1;
+                    None
+                }
+            })
+            .collect();
+
+        LiveFrame {
+            frame: LiveTickFrame {
+                tick,
+                events: event_views,
+                inferences,
+            },
+            verified_count,
+            unverified_count,
+            privacy_redacted_count,
+            privacy_redacted_inference_count,
+        }
+    }
+}
 
 /// Shape of the upstream `GET /api/field` response (ADR-262 P3).
 ///
 /// The viewer only needs `events`; `signer_pubkey` / `dev_signing_key` are
-/// accepted (and surfaced) but are not trusted blindly — verification is done
-/// per-event against each event's own embedded `signer_pubkey_hex`.
+/// accepted for compatibility but are informational only. Trust comes from the
+/// independently injected [`TrustedKeyRegistry`], never this payload.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ApiFieldPayload {
     /// The bounded ring of field events the upstream is currently serving.
@@ -50,94 +201,254 @@ pub struct ApiFieldPayload {
     pub dev_signing_key: Option<String>,
 }
 
-/// The result of ingesting one batch of upstream events: a renderable
-/// [`TickFrame`] plus per-batch verification counters used for the LIVE banner /
-/// integrity panel. Only **verified** events are fused into the inferences.
+/// Stable, non-identifying rejection categories exposed by the live viewer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveTrustRejectionCode {
+    /// A compatibility-only simulation error reached the live boundary.
+    TrustPolicyRejected,
+    /// Event or sensor identity was empty.
+    MalformedIdentity,
+    /// Synthetic evidence was presented to a live policy.
+    SyntheticRejected,
+    /// No signer key was present.
+    MissingPublicKey,
+    /// The signer key was not independently enrolled.
+    UnknownKey,
+    /// The sensor was not independently enrolled.
+    UnknownSensor,
+    /// The sensor was bound to a different key.
+    SensorKeyMismatch,
+    /// The enrolled key was revoked.
+    RevokedKey,
+    /// The event fell outside the maximum age.
+    StaleTimestamp,
+    /// The event exceeded future clock tolerance.
+    FutureTimestamp,
+    /// The exact prior event was replayed.
+    DuplicateEvent,
+    /// The event did not advance its sensor watermark.
+    NonmonotonicReplay,
+    /// No detached signature was present.
+    MissingSignature,
+    /// Signature or key encoding was malformed.
+    MalformedSignature,
+    /// Detached signature verification failed.
+    SignatureVerificationFailed,
+    /// Canonical event encoding failed.
+    EventEncodingError,
+    /// Internal trust configuration or replay state failed closed.
+    TrustPolicyError,
+}
+
+/// A public trust decision that carries no attacker-controlled error text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LiveTrustDecisionView {
+    /// Whether the event passed the configured live trust policy.
+    pub accepted: bool,
+    /// Stable diagnostic code for a rejection, absent on acceptance.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rejection_code: Option<LiveTrustRejectionCode>,
+}
+
+/// The disposition of event details under the default network privacy policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LivePrivacyDisposition {
+    /// P1 or P2 metadata allowed by the default network policy.
+    Allowed,
+    /// Event details denied by the default network ceiling.
+    Redacted,
+    /// P4 details withheld because no consent was supplied to the viewer.
+    ConsentRequired,
+}
+
+/// Non-identifying event details permitted by the default network policy.
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveEventDetails {
+    /// A whitelisted modality code. Unknown upstream strings become `other`.
+    pub modality: &'static str,
+    /// Human-readable form of the whitelisted modality.
+    pub modality_label: &'static str,
+    /// Observation confidence, which contains no direct identifier.
+    pub confidence: f32,
+}
+
+/// Fail-closed public projection for one live event.
+///
+/// This type deliberately has no event, device or zone id, timestamp, raw
+/// label, receipt hash, signer key, signature, model id or calibration id.
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveEventView {
+    /// Batch-local ordinal used only for display ordering.
+    pub sequence: usize,
+    /// Privacy classification without the protected event contents.
+    pub privacy: PrivacyBadge,
+    /// Safe trust outcome and stable rejection code.
+    pub trust: LiveTrustDecisionView,
+    /// Why optional details are present or withheld.
+    pub privacy_disposition: LivePrivacyDisposition,
+    /// Details that passed the default network privacy guard.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<LiveEventDetails>,
+}
+
+/// Fail-closed public projection for a fused live inference.
+///
+/// Supporting event ids, contradicting event ids and model ids remain inside
+/// the process. P4 and P5 inferences are omitted without consent or binding.
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveInferenceView {
+    /// Policy-owned inference label.
+    pub label: String,
+    /// Confidence of the inference.
+    pub confidence: f32,
+    /// Privacy classification.
+    pub privacy: PrivacyBadge,
+}
+
+impl From<&FieldInference> for LiveInferenceView {
+    fn from(inference: &FieldInference) -> Self {
+        Self {
+            label: inference.label.clone(),
+            confidence: inference.confidence,
+            privacy: inference.privacy_class.into(),
+        }
+    }
+}
+
+/// Public live frame containing only privacy-filtered projections.
+#[derive(Debug, Clone, Serialize)]
+pub struct LiveTickFrame {
+    /// Batch sequence assigned by the viewer.
+    pub tick: usize,
+    /// Redacted per-event diagnostics.
+    pub events: Vec<LiveEventView>,
+    /// Inferences permitted by the default network privacy policy.
+    pub inferences: Vec<LiveInferenceView>,
+}
+
+/// The result of ingesting one batch of upstream events: a public redacted
+/// projection plus trust and privacy counters used by the LIVE integrity panel.
+/// Only trust-accepted events are fused, and only privacy-allowed projections
+/// reach the broadcast channel.
 #[derive(Debug, Clone, Serialize)]
 pub struct LiveFrame {
-    /// The renderable frame (event log + fused room state) for this batch.
-    pub frame: TickFrame,
-    /// How many ingested events verified (receipt OK / §11-fusable).
+    /// The renderable, non-identifying public frame for this batch.
+    pub frame: LiveTickFrame,
+    /// How many ingested events passed the configured live trust policy.
     pub verified_count: usize,
-    /// How many ingested events were flagged **unverified** (and not fused).
+    /// How many ingested events were rejected and not fused.
     pub unverified_count: usize,
+    /// Event details withheld by the default network privacy guard.
+    pub privacy_redacted_count: usize,
+    /// Fused inferences omitted by the default network privacy guard.
+    pub privacy_redacted_inference_count: usize,
 }
 
 /// Human-readable label for a modality string code (mirrors `runtime`).
-fn modality_label(code: &str) -> String {
+fn public_modality(code: &str) -> (&'static str, &'static str) {
     match code {
-        "wifi_csi" => "WiFi CSI",
-        "mmwave_radar" => "mmWave Radar",
-        "infrared_thermal" => "Infrared Thermal",
-        other => other,
+        "wifi_csi" => ("wifi_csi", "WiFi CSI"),
+        "mmwave_radar" => ("mmwave_radar", "mmWave Radar"),
+        "infrared_thermal" => ("infrared_thermal", "Infrared Thermal"),
+        _ => ("other", "Other camera-free sensor"),
     }
-    .to_string()
 }
 
-/// Build an [`EventView`] for an upstream event, carrying its verified ✓/✗
-/// receipt badge. This reuses the synthetic path's [`ReceiptView`] so the
-/// dashboard's receipt modal is byte-for-byte identical regardless of source.
-fn event_view(ev: &FieldEvent) -> EventView {
-    EventView {
-        event_id: ev.event_id.clone(),
-        timestamp_ns: ev.timestamp_ns,
-        modality: ev.sensor.modality.clone(),
-        modality_label: modality_label(&ev.sensor.modality),
-        device_id: ev.sensor.device_id.clone(),
-        zone_id: ev.observation.zone_id.clone(),
-        confidence: ev.observation.confidence,
-        privacy: ev.observation.privacy_class.into(),
-        truth_labels: ev.observation.labels.clone(),
-        receipt: ReceiptView::from_event(ev),
+fn public_event_view(
+    event: &FieldEvent,
+    sequence: usize,
+    trust: LiveTrustDecisionView,
+    guard: &DefaultPrivacyGuard,
+) -> LiveEventView {
+    let decision = guard.authorize(
+        event.observation.privacy_class,
+        Destination::Network,
+        false,
+        false,
+    );
+    let (privacy_disposition, details) = match decision {
+        PrivacyDecision::Allow => {
+            let (modality, modality_label) = public_modality(&event.sensor.modality);
+            (
+                LivePrivacyDisposition::Allowed,
+                Some(LiveEventDetails {
+                    modality,
+                    modality_label,
+                    confidence: event.observation.confidence,
+                }),
+            )
+        }
+        PrivacyDecision::RequiresConsent(_) => (LivePrivacyDisposition::ConsentRequired, None),
+        PrivacyDecision::Deny(_) => (LivePrivacyDisposition::Redacted, None),
+    };
+
+    LiveEventView {
+        sequence,
+        privacy: event.observation.privacy_class.into(),
+        trust,
+        privacy_disposition,
+        details,
+    }
+}
+
+fn network_allowed(guard: &DefaultPrivacyGuard, privacy_class: rufield_core::PrivacyClass) -> bool {
+    matches!(
+        guard.authorize(privacy_class, Destination::Network, false, false),
+        PrivacyDecision::Allow
+    )
+}
+
+fn trust_rejection_code(error: &FusionError) -> LiveTrustRejectionCode {
+    let FusionError::TrustRejected { reason, .. } = error else {
+        return LiveTrustRejectionCode::TrustPolicyRejected;
+    };
+    match reason {
+        TrustError::MalformedIdentity(_) => LiveTrustRejectionCode::MalformedIdentity,
+        TrustError::SyntheticRejected => LiveTrustRejectionCode::SyntheticRejected,
+        TrustError::MissingPublicKey => LiveTrustRejectionCode::MissingPublicKey,
+        TrustError::UnknownKey => LiveTrustRejectionCode::UnknownKey,
+        TrustError::UnknownSensor(_) => LiveTrustRejectionCode::UnknownSensor,
+        TrustError::SensorKeyMismatch(_) => LiveTrustRejectionCode::SensorKeyMismatch,
+        TrustError::RevokedKey => LiveTrustRejectionCode::RevokedKey,
+        TrustError::StaleTimestamp => LiveTrustRejectionCode::StaleTimestamp,
+        TrustError::FutureTimestamp => LiveTrustRejectionCode::FutureTimestamp,
+        TrustError::DuplicateEvent(_) => LiveTrustRejectionCode::DuplicateEvent,
+        TrustError::NonMonotonicReplay { .. } => LiveTrustRejectionCode::NonmonotonicReplay,
+        TrustError::Provenance(ProvenanceError::MissingSignature) => {
+            LiveTrustRejectionCode::MissingSignature
+        }
+        TrustError::Provenance(ProvenanceError::BadEncoding(_)) => {
+            LiveTrustRejectionCode::MalformedSignature
+        }
+        TrustError::Provenance(ProvenanceError::VerifyFailed) => {
+            LiveTrustRejectionCode::SignatureVerificationFailed
+        }
+        TrustError::Provenance(ProvenanceError::Serialize(_)) => {
+            LiveTrustRejectionCode::EventEncodingError
+        }
+        TrustError::InvalidRegistry(_) | TrustError::ReplayState(_) => {
+            LiveTrustRejectionCode::TrustPolicyError
+        }
     }
 }
 
 /// Turn a batch of freshly-ingested upstream [`FieldEvent`]s into a renderable
 /// [`LiveFrame`].
 ///
-/// Verification happens **here, on ingest**: each event's provenance receipt is
-/// checked with [`is_fusable`]. Verified events are fed through the *same*
-/// `RuFieldFusion` engine the synthetic path uses — so the room-state / fusion
-/// graph display path is identical — and only they contribute to inferences.
-/// Unverified events are still returned in `frame.events` (so the operator can
-/// see them, flagged ✗ via `receipt.verified == false`) but are **dropped from
-/// fusion** — forged data is never rendered as trusted.
+/// The caller must inject and retain a [`LiveProcessor`]. Its production or
+/// captured-replay verifier authorizes each event before graph and window
+/// mutation. Rejected events remain visible with a ✗ badge but cannot support
+/// an inference.
 #[must_use]
-pub fn frame_from_events(tick: usize, events: &[FieldEvent]) -> LiveFrame {
-    let mut engine = RuFieldFusion::new();
-    let mut event_views = Vec::with_capacity(events.len());
-    let mut verified_count = 0usize;
-    let mut unverified_count = 0usize;
-    let mut max_ts = 0u64;
-
-    for ev in events {
-        max_ts = max_ts.max(ev.timestamp_ns);
-        event_views.push(event_view(ev));
-
-        if is_fusable(ev) {
-            verified_count += 1;
-            // Only verified events are fused. `ingest` itself re-checks §11, so
-            // this is belt-and-suspenders: forged data cannot reach the engine.
-            let _ = engine.ingest(ev.clone());
-        } else {
-            // Flagged unverified — surfaced in the log with a ✗ badge, never fused.
-            unverified_count += 1;
-        }
-    }
-
-    let produced = engine.infer(&InferenceQuery::all()).unwrap_or_default();
-    let inferences: Vec<InferenceView> = produced.iter().map(InferenceView::from).collect();
-
-    LiveFrame {
-        frame: TickFrame {
-            tick,
-            timestamp_ns: max_ts,
-            events: event_views,
-            inferences,
-        },
-        verified_count,
-        unverified_count,
-    }
+pub fn frame_from_events(
+    processor: &mut LiveProcessor,
+    tick: usize,
+    events: &[FieldEvent],
+    now_ns: u64,
+) -> LiveFrame {
+    processor.process_events_at(tick, events, now_ns)
 }
 
 /// Parse an upstream `/api/field` JSON payload and build a renderable
@@ -147,10 +458,15 @@ pub fn frame_from_events(tick: usize, events: &[FieldEvent]) -> LiveFrame {
 /// # Errors
 /// Returns the serde error string if the payload is not a valid
 /// [`ApiFieldPayload`] (e.g. malformed or not a `FieldEvent` ring).
-pub fn frame_from_api_payload(tick: usize, json: &str) -> Result<LiveFrame, String> {
+pub fn frame_from_api_payload(
+    processor: &mut LiveProcessor,
+    tick: usize,
+    json: &str,
+    now_ns: u64,
+) -> Result<LiveFrame, String> {
     let payload: ApiFieldPayload =
         serde_json::from_str(json).map_err(|e| format!("decode /api/field: {e}"))?;
-    Ok(frame_from_events(tick, &payload.events))
+    Ok(frame_from_events(processor, tick, &payload.events, now_ns))
 }
 
 /// Parse a single upstream `/ws/field` SSE `data:` payload (one serialized
@@ -158,33 +474,64 @@ pub fn frame_from_api_payload(tick: usize, json: &str) -> Result<LiveFrame, Stri
 ///
 /// # Errors
 /// Returns the serde error string if the line is not a valid `FieldEvent`.
-pub fn frame_from_ws_event(tick: usize, json: &str) -> Result<LiveFrame, String> {
+pub fn frame_from_ws_event(
+    processor: &mut LiveProcessor,
+    tick: usize,
+    json: &str,
+    now_ns: u64,
+) -> Result<LiveFrame, String> {
     let ev: FieldEvent =
         serde_json::from_str(json).map_err(|e| format!("decode /ws/field event: {e}"))?;
-    Ok(frame_from_events(tick, std::slice::from_ref(&ev)))
+    Ok(frame_from_events(
+        processor,
+        tick,
+        std::slice::from_ref(&ev),
+        now_ns,
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use rufield_adapters::{run_demo, SimConfig};
+    use rufield_provenance::Signer;
 
-    /// Borrow real, signed, §11-fusable events from the synthetic adapter — they
-    /// carry genuine ed25519 receipts, so they exercise the *exact* verification
-    /// the live path performs on real upstream events. (We are using the adapter
-    /// only as a *signed-event factory* here; the live path itself never runs the
-    /// simulator.)
-    fn real_signed_events(n: usize) -> Vec<FieldEvent> {
-        run_demo(&SimConfig::default())
+    const NOW_NS: u64 = 1_800_000_000_000_000_000;
+
+    /// Use the adapter only as an event factory, then remove its synthetic
+    /// classification and sign with the explicitly enrolled test sensor key.
+    fn real_signed_events(n: usize, signer: &Signer) -> Vec<FieldEvent> {
+        let mut events: Vec<FieldEvent> = run_demo(&SimConfig::default())
             .into_iter()
             .map(|se| se.event)
             .take(n)
-            .collect()
+            .collect();
+        for (index, event) in events.iter_mut().enumerate() {
+            event.timestamp_ns = NOW_NS + index as u64;
+            event.tensor.timestamp_ns = event.timestamp_ns;
+            event.provenance.synthetic = false;
+            signer.sign_event(event).unwrap();
+        }
+        events
+    }
+
+    fn production_processor(events: &[FieldEvent], signer: &Signer) -> LiveProcessor {
+        let mut registry = TrustedKeyRegistry::new();
+        for event in events {
+            registry
+                .enroll_sensor_key(&event.sensor.device_id, signer.public_hex())
+                .unwrap();
+        }
+        LiveTrustConfig::production(registry)
+            .into_processor()
+            .unwrap()
     }
 
     #[test]
     fn api_payload_deserializes_verifies_and_renders() {
-        let events = real_signed_events(3);
+        let signer = Signer::from_seed(&[31; 32]);
+        let events = real_signed_events(3, &signer);
+        let mut processor = production_processor(&events, &signer);
         let payload = serde_json::json!({
             "events": events,
             "signer_pubkey": "deadbeef",
@@ -192,15 +539,15 @@ mod tests {
         })
         .to_string();
 
-        let live = frame_from_api_payload(0, &payload).expect("payload decodes");
-        // All three are real signed/synthetic events ⇒ all verify, none flagged.
+        let live = frame_from_api_payload(&mut processor, 0, &payload, NOW_NS + 10)
+            .expect("payload decodes");
         assert_eq!(live.verified_count, 3);
         assert_eq!(live.unverified_count, 0);
         assert_eq!(live.frame.events.len(), 3);
-        // Every rendered event carries a verified ✓ receipt and is §11-fusable.
+        // Every public diagnostic reports acceptance without exposing a receipt.
         for ev in &live.frame.events {
-            assert!(ev.receipt.verified, "real signed event must verify");
-            assert!(ev.receipt.fusable, "verified event must be §11-fusable");
+            assert!(ev.trust.accepted, "trusted event must be accepted");
+            assert!(ev.trust.rejection_code.is_none());
         }
         // Verified events produce renderable room-state inferences.
         assert!(
@@ -211,43 +558,35 @@ mod tests {
 
     #[test]
     fn tampered_event_is_flagged_unverified_and_not_fused() {
-        let mut events = real_signed_events(2);
-        // Tamper one event AFTER it was signed: flip a tensor value. Its receipt
-        // can no longer verify, and it is not synthetic-after-tamper-trusted —
-        // wait: synthetic events are fusable regardless. To exercise the forged-
-        // data path we must drop the synthetic flag so verification is required.
-        events[0].provenance.synthetic = false;
+        let signer = Signer::from_seed(&[32; 32]);
+        let mut events = real_signed_events(2, &signer);
+        let mut processor = production_processor(&events, &signer);
         events[0].tensor.values[0] += 13.5;
 
-        let live = frame_from_events(0, &events);
-        // Event 0: not synthetic + broken signature ⇒ unverified, not fused.
-        assert!(
-            !live.frame.events[0].receipt.verified,
-            "tampered ⇒ ✗ verified"
-        );
-        assert!(
-            !live.frame.events[0].receipt.fusable,
-            "tampered ⇒ not fusable"
+        let live = frame_from_events(&mut processor, 0, &events, NOW_NS + 10);
+        // Event 0: not synthetic + broken signature ⇒ rejected, not fused.
+        assert!(!live.frame.events[0].trust.accepted);
+        assert_eq!(
+            live.frame.events[0].trust.rejection_code,
+            Some(LiveTrustRejectionCode::SignatureVerificationFailed)
         );
         assert_eq!(live.unverified_count, 1, "one event flagged unverified");
 
-        // It is still SURFACED in the event log (so forgery is visible)...
+        // It is still surfaced as a redacted diagnostic so forgery is visible.
         assert_eq!(live.frame.events.len(), 2);
-        // ...but it must not contribute to any inference's supporting set.
-        let forged_id = &live.frame.events[0].event_id;
-        for inf in &live.frame.inferences {
-            assert!(
-                !inf.supporting_events.contains(forged_id),
-                "forged event must never support a trusted inference"
-            );
-        }
+        assert!(!serde_json::to_string(&live)
+            .unwrap()
+            .contains(&events[0].event_id));
     }
 
     #[test]
     fn ws_event_renders_single_frame() {
-        let ev = real_signed_events(1).remove(0);
+        let signer = Signer::from_seed(&[33; 32]);
+        let ev = real_signed_events(1, &signer).remove(0);
+        let mut processor = production_processor(std::slice::from_ref(&ev), &signer);
         let json = serde_json::to_string(&ev).unwrap();
-        let live = frame_from_ws_event(5, &json).expect("ws event decodes");
+        let live =
+            frame_from_ws_event(&mut processor, 5, &json, NOW_NS + 10).expect("ws event decodes");
         assert_eq!(live.frame.tick, 5);
         assert_eq!(live.frame.events.len(), 1);
         assert_eq!(live.verified_count, 1);
@@ -255,7 +594,188 @@ mod tests {
 
     #[test]
     fn malformed_payload_errors_not_panics() {
-        assert!(frame_from_api_payload(0, "not json").is_err());
-        assert!(frame_from_ws_event(0, "{\"nope\":1}").is_err());
+        let signer = Signer::from_seed(&[34; 32]);
+        let events = real_signed_events(1, &signer);
+        let mut processor = production_processor(&events, &signer);
+        assert!(frame_from_api_payload(&mut processor, 0, "not json", NOW_NS).is_err());
+        assert!(frame_from_ws_event(&mut processor, 0, "{\"nope\":1}", NOW_NS).is_err());
+    }
+
+    #[test]
+    fn live_self_signed_event_cannot_mutate_fusion() {
+        let enrolled = Signer::from_seed(&[35; 32]);
+        let attacker = Signer::from_seed(&[36; 32]);
+        let mut events = real_signed_events(1, &attacker);
+        events[0].event_id = "SECRET_REJECTED_EVENT_ID_119".into();
+        events[0].observation.zone_id = Some("SECRET_REJECTED_ZONE_ID_229".into());
+        events[0].observation.labels = vec!["SECRET_REJECTED_RAW_LABEL_339".into()];
+        events[0].provenance.raw_hash = "sha256:SECRET_REJECTED_RAW_HASH_449".into();
+        attacker.sign_event(&mut events[0]).unwrap();
+        let rejected_signature = events[0].provenance.signature_hex.clone().unwrap();
+        let mut registry = TrustedKeyRegistry::new();
+        registry
+            .enroll_sensor_key(&events[0].sensor.device_id, enrolled.public_hex())
+            .unwrap();
+        let mut processor = LiveTrustConfig::production(registry)
+            .into_processor()
+            .unwrap();
+
+        let live = frame_from_events(&mut processor, 0, &events, NOW_NS + 10);
+        assert_eq!(live.verified_count, 0);
+        assert_eq!(live.unverified_count, 1);
+        assert!(!live.frame.events[0].trust.accepted);
+        assert_eq!(
+            live.frame.events[0].trust.rejection_code,
+            Some(LiveTrustRejectionCode::UnknownKey)
+        );
+        let rendered = serde_json::to_string(&live).unwrap();
+        for secret in [
+            attacker.public_hex(),
+            rejected_signature,
+            "SECRET_REJECTED_EVENT_ID_119".into(),
+            "SECRET_REJECTED_ZONE_ID_229".into(),
+            "SECRET_REJECTED_RAW_LABEL_339".into(),
+            "SECRET_REJECTED_RAW_HASH_449".into(),
+        ] {
+            assert!(
+                !rendered.contains(&secret),
+                "rejected event leaked {secret}"
+            );
+        }
+        assert_eq!(processor.fusion().graph().node_count(), 0);
+        assert!(processor
+            .fusion()
+            .trust_verifier()
+            .export_replay_state()
+            .watermarks
+            .is_empty());
+    }
+
+    #[test]
+    fn live_synthetic_event_cannot_mutate_fusion() {
+        let signer = Signer::from_seed(&[37; 32]);
+        let mut events = real_signed_events(1, &signer);
+        events[0].provenance.synthetic = true;
+        signer.sign_event(&mut events[0]).unwrap();
+        let mut processor = production_processor(&events, &signer);
+
+        let live = frame_from_events(&mut processor, 0, &events, NOW_NS + 10);
+        assert_eq!(live.verified_count, 0);
+        assert_eq!(live.unverified_count, 1);
+        assert!(!live.frame.events[0].trust.accepted);
+        assert_eq!(
+            live.frame.events[0].trust.rejection_code,
+            Some(LiveTrustRejectionCode::SyntheticRejected)
+        );
+        assert_eq!(processor.fusion().graph().node_count(), 0);
+        assert!(processor
+            .fusion()
+            .trust_verifier()
+            .export_replay_state()
+            .watermarks
+            .is_empty());
+    }
+
+    #[test]
+    fn live_public_projection_never_contains_sensitive_event_fields() {
+        let signer = Signer::from_seed(&[38; 32]);
+        let mut events = real_signed_events(1, &signer);
+        let event = &mut events[0];
+        event.event_id = "SECRET_EVENT_ID_993".into();
+        event.sensor.device_id = "SECRET_DEVICE_ID_773".into();
+        event.sensor.vendor = "SECRET_VENDOR_221".into();
+        event.sensor.placement = "SECRET_PLACEMENT_551".into();
+        event.observation.zone_id = Some("SECRET_ZONE_ID_662".into());
+        event.observation.labels = vec!["SECRET_RAW_LABEL_884".into()];
+        event.provenance.raw_hash = "sha256:SECRET_RAW_HASH_123".into();
+        event.provenance.firmware_hash = "sha256:SECRET_FIRMWARE_HASH_456".into();
+        event.provenance.model_id = "SECRET_MODEL_ID_789".into();
+        event.provenance.calibration_id = "SECRET_CALIBRATION_ID_147".into();
+        signer.sign_event(event).unwrap();
+        let signer_key = event.provenance.signer_pubkey_hex.clone().unwrap();
+        let signature = event.provenance.signature_hex.clone().unwrap();
+
+        let mut processor = production_processor(&events, &signer);
+        let live = frame_from_events(&mut processor, 9, &events, NOW_NS + 10);
+        assert!(live.frame.events[0].trust.accepted);
+
+        let rendered = serde_json::to_string(&live).unwrap();
+        for secret in [
+            "SECRET_EVENT_ID_993",
+            "SECRET_DEVICE_ID_773",
+            "SECRET_VENDOR_221",
+            "SECRET_PLACEMENT_551",
+            "SECRET_ZONE_ID_662",
+            "SECRET_RAW_LABEL_884",
+            "SECRET_RAW_HASH_123",
+            "SECRET_FIRMWARE_HASH_456",
+            "SECRET_MODEL_ID_789",
+            "SECRET_CALIBRATION_ID_147",
+            &signer_key,
+            &signature,
+        ] {
+            assert!(!rendered.contains(secret), "live output leaked {secret}");
+        }
+        for forbidden_key in [
+            "event_id",
+            "device_id",
+            "zone_id",
+            "truth_labels",
+            "receipt",
+            "raw_hash",
+            "firmware_hash",
+            "signer_pubkey_hex",
+            "signature_hex",
+            "supporting_events",
+            "contradicting_events",
+            "model_id",
+            "calibration_id",
+        ] {
+            assert!(
+                !rendered.contains(&format!("\"{forbidden_key}\"")),
+                "live output exposed forbidden field {forbidden_key}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_live_privacy_guard_redacts_disallowed_event_details() {
+        let signer = Signer::from_seed(&[39; 32]);
+        let mut events = real_signed_events(1, &signer);
+        events[0].observation.privacy_class = rufield_core::PrivacyClass::P4;
+        events[0].tensor.privacy_class = rufield_core::PrivacyClass::P4;
+        signer.sign_event(&mut events[0]).unwrap();
+        let mut processor = production_processor(&events, &signer);
+
+        let live = frame_from_events(&mut processor, 0, &events, NOW_NS + 10);
+        assert!(live.frame.events[0].trust.accepted);
+        assert_eq!(
+            live.frame.events[0].privacy_disposition,
+            LivePrivacyDisposition::ConsentRequired
+        );
+        assert!(live.frame.events[0].details.is_none());
+        assert_eq!(live.privacy_redacted_count, 1);
+    }
+
+    #[test]
+    fn live_processor_rejects_simulation_mode() {
+        let config = LiveTrustConfig {
+            policy: TrustPolicy::simulation(),
+            registry: TrustedKeyRegistry::new(),
+            replay_state: None,
+        };
+        assert!(matches!(
+            config.into_processor(),
+            Err(TrustError::InvalidRegistry(_))
+        ));
+    }
+
+    #[test]
+    fn live_processor_rejects_empty_production_registry() {
+        let config = LiveTrustConfig::production(TrustedKeyRegistry::new());
+        assert!(matches!(
+            config.into_processor(),
+            Err(TrustError::InvalidRegistry(_))
+        ));
     }
 }

--- a/crates/rufield-viewer/src/main.rs
+++ b/crates/rufield-viewer/src/main.rs
@@ -6,19 +6,25 @@
 //!   cargo run -p rufield-viewer -- --seed 7 --tick-ms 200
 //!   cargo run -p rufield-viewer -- --no-loop     # stop stream at end of demo
 //!
-//! Usage (live — consume a real RuField upstream, ADR-262 P3):
-//!   cargo run -p rufield-viewer -- --source live --upstream http://127.0.0.1:8080
+//! Usage (live — ADR-261 trust over the ADR-262 P3 transport):
+//!   cargo run -p rufield-viewer -- --source live --upstream http://127.0.0.1:8080 \
+//!     --sensor-key sensor_room_01=<ed25519-public-key-hex>
 //!
 //! Env overrides: `RUFIELD_VIEWER_PORT`, `RUFIELD_VIEWER_SEED`,
 //! `RUFIELD_VIEWER_TICK_MS`, `RUFIELD_VIEWER_SOURCE` (`synthetic`|`live`),
-//! `RUFIELD_VIEWER_UPSTREAM`, `RUFIELD_VIEWER_POLL_MS`.
+//! `RUFIELD_VIEWER_UPSTREAM`, `RUFIELD_VIEWER_POLL_MS`,
+//! `RUFIELD_VIEWER_SENSOR_KEYS` (comma-separated `sensor=key` bindings), and
+//! `RUFIELD_VIEWER_TRUST_MODE` (`production`|`captured_replay`).
 //!
 //! In SYNTHETIC mode everything served is simulated — there is no hardware. In
-//! LIVE mode the viewer renders ONLY receipt-verified events from the upstream;
+//! LIVE mode fuses ONLY events accepted by the enrolled sensor trust policy;
 //! if the upstream is unreachable it shows DISCONNECTED, never synthetic data.
 
+use rufield_provenance::{
+    TrustPolicy, TrustedKeyRegistry, DEFAULT_MAX_EVENT_AGE_NS, DEFAULT_MAX_FUTURE_SKEW_NS,
+};
 use rufield_viewer::{
-    app, SourceMode, ViewerConfig, DEFAULT_POLL_MS, DEFAULT_SEED, DEFAULT_TICK_MS,
+    app, LiveTrustConfig, SourceMode, ViewerConfig, DEFAULT_POLL_MS, DEFAULT_SEED, DEFAULT_TICK_MS,
 };
 
 #[tokio::main]
@@ -65,14 +71,33 @@ async fn main() {
         }
     };
 
+    let live_trust = if source.is_live() {
+        match live_trust_config(&args) {
+            Ok(config) => Some(config),
+            Err(error) => {
+                eprintln!("invalid live trust configuration: {error}");
+                std::process::exit(2);
+            }
+        }
+    } else {
+        None
+    };
+
     let config = ViewerConfig {
         seed,
         tick_ms,
         loop_stream,
         source: source.clone(),
         poll_ms,
+        live_trust,
     };
-    let router = app(config);
+    let router = match app(config) {
+        Ok(router) => router,
+        Err(error) => {
+            eprintln!("viewer configuration rejected: {error}");
+            std::process::exit(2);
+        }
+    };
 
     let addr = format!("127.0.0.1:{port}");
     let listener = match tokio::net::TcpListener::bind(&addr).await {
@@ -89,10 +114,12 @@ async fn main() {
             println!("  seed={seed}  tick_ms={tick_ms}  loop={loop_stream}");
         }
         SourceMode::Live { upstream } => {
-            println!("RuField MFS viewer (LIVE — ingesting {upstream}, ADR-262 P3)");
+            println!(
+                "RuField MFS viewer (LIVE — ingesting {upstream}, ADR-262 P3 transport; ADR-261 trust)"
+            );
             println!("  upstream={upstream}  poll_ms={poll_ms}");
             println!(
-                "  receipts verified on ingest; unreachable ⇒ DISCONNECTED (no synthetic fallback)"
+                "  enrolled sensor trust enforced; unreachable ⇒ DISCONNECTED (no synthetic fallback)"
             );
         }
     }
@@ -112,4 +139,99 @@ fn arg_value(args: &[String], flag: &str) -> Option<String> {
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1))
         .cloned()
+}
+
+fn arg_values(args: &[String], flag: &str) -> Vec<String> {
+    args.iter()
+        .enumerate()
+        .filter_map(|(index, value)| {
+            if value == flag {
+                args.get(index + 1).cloned()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn live_trust_config(args: &[String]) -> Result<LiveTrustConfig, String> {
+    let mode = arg_value(args, "--trust-mode")
+        .or_else(|| std::env::var("RUFIELD_VIEWER_TRUST_MODE").ok())
+        .unwrap_or_else(|| "production".into());
+
+    let mut bindings = arg_values(args, "--sensor-key");
+    if let Ok(encoded) = std::env::var("RUFIELD_VIEWER_SENSOR_KEYS") {
+        bindings.extend(
+            encoded
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
+        );
+    }
+    if bindings.is_empty() {
+        return Err(
+            "at least one --sensor-key sensor_id=public_key_hex binding is required".into(),
+        );
+    }
+
+    let mut registry = TrustedKeyRegistry::new();
+    for binding in bindings {
+        let (sensor, key) = binding.split_once('=').ok_or_else(|| {
+            format!("invalid sensor-key binding {binding:?}; expected sensor=key")
+        })?;
+        registry
+            .enroll_sensor_key(sensor, key)
+            .map_err(|error| error.to_string())?;
+    }
+
+    let policy = match mode.as_str() {
+        "production" => {
+            let max_age_ns = duration_override_ns(
+                args,
+                "--max-event-age-ms",
+                "RUFIELD_VIEWER_MAX_EVENT_AGE_MS",
+                DEFAULT_MAX_EVENT_AGE_NS,
+            )?;
+            let future_skew_ns = duration_override_ns(
+                args,
+                "--max-future-skew-ms",
+                "RUFIELD_VIEWER_MAX_FUTURE_SKEW_MS",
+                DEFAULT_MAX_FUTURE_SKEW_NS,
+            )?;
+            TrustPolicy::production_with_window(max_age_ns, future_skew_ns)
+        }
+        "captured_replay" => TrustPolicy::captured_replay(),
+        "simulation" => {
+            return Err("simulation trust mode is forbidden for a live source".into());
+        }
+        other => {
+            return Err(format!(
+                "unknown trust mode {other:?}; expected production or captured_replay"
+            ));
+        }
+    };
+
+    Ok(LiveTrustConfig {
+        policy,
+        registry,
+        replay_state: None,
+    })
+}
+
+fn duration_override_ns(
+    args: &[String],
+    flag: &str,
+    environment: &str,
+    default_ns: u64,
+) -> Result<u64, String> {
+    let Some(value) = arg_value(args, flag).or_else(|| std::env::var(environment).ok()) else {
+        return Ok(default_ns);
+    };
+    let milliseconds = value
+        .parse::<u64>()
+        .map_err(|_| format!("{flag} must be an unsigned integer"))?;
+    milliseconds
+        .checked_mul(1_000_000)
+        .ok_or_else(|| format!("{flag} is too large"))
 }

--- a/crates/rufield-viewer/src/runtime.rs
+++ b/crates/rufield-viewer/src/runtime.rs
@@ -51,15 +51,16 @@ pub struct ReceiptView {
     pub signature_hex: Option<String>,
     /// Hex ed25519 signer public key, if present.
     pub signer_pubkey_hex: Option<String>,
-    /// Whether the signature verifies against the event (`verify_event`).
+    /// Whether integrity verification and the active source trust policy accept
+    /// this event. In simulation this is raw signature verification.
     pub verified: bool,
-    /// Whether the event passes the §11 fusability invariant.
+    /// Whether the active source trust policy permits fusion.
     pub fusable: bool,
 }
 
 impl ReceiptView {
-    /// Build a receipt view from an event, computing the verified ✓/✗ and
-    /// §11-fusable flags. Shared by the synthetic and live-ingest paths.
+    /// Build a simulation receipt view from an event, computing detached
+    /// signature verification and the legacy §11 simulation fusability flag.
     #[must_use]
     pub fn from_event(ev: &FieldEvent) -> Self {
         ReceiptView {
@@ -72,6 +73,26 @@ impl ReceiptView {
             signer_pubkey_hex: ev.provenance.signer_pubkey_hex.clone(),
             verified: verify_event(ev).is_ok(),
             fusable: is_fusable(ev),
+        }
+    }
+
+    /// Build a live receipt view from a production trust decision.
+    ///
+    /// Unlike [`Self::from_event`], this never calls the legacy stateless
+    /// fusability helper. A self-signed but unenrolled event therefore renders
+    /// as rejected even when its detached signature is mathematically valid.
+    #[must_use]
+    pub fn from_live_decision(ev: &FieldEvent, accepted: bool) -> Self {
+        ReceiptView {
+            raw_hash: ev.provenance.raw_hash.clone(),
+            firmware_hash: ev.provenance.firmware_hash.clone(),
+            model_id: ev.provenance.model_id.clone(),
+            calibration_id: ev.provenance.calibration_id.clone(),
+            synthetic: ev.provenance.synthetic,
+            signature_hex: ev.provenance.signature_hex.clone(),
+            signer_pubkey_hex: ev.provenance.signer_pubkey_hex.clone(),
+            verified: accepted,
+            fusable: accepted,
         }
     }
 }

--- a/crates/rufield-viewer/src/server.rs
+++ b/crates/rufield-viewer/src/server.rs
@@ -1,5 +1,6 @@
-//! The Axum web server (ADR-260 §14 Layer 7). Read-only: it drives the
-//! deterministic synthetic pipeline and serves it to a single-page dashboard.
+//! The Axum web server (ADR-260 §14 Layer 7). Read-only: it serves either the
+//! explicitly labeled deterministic synthetic pipeline or a fail-closed live
+//! pipeline backed by an injected sensor trust registry.
 //!
 //! Routes:
 //! - `GET /`          → the dashboard HTML page.
@@ -8,8 +9,9 @@
 //! - `GET /api/run`   → the full deterministic run as JSON (non-streaming).
 //! - `GET /events`    → Server-Sent Events: each tick frame, paced for viewing.
 //!
-//! There is **no hardware** and **no live sensor**: everything streamed here is
-//! the `SyntheticSim` demo replayed at a watchable cadence.
+//! Synthetic remains the default. Live startup fails unless
+//! [`ViewerConfig::live_trust`] contains a production or captured-replay policy
+//! and independently enrolled sensor keys. Live never falls back to synthetic.
 
 use axum::{
     extract::{Query, State},
@@ -27,7 +29,7 @@ use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
 
-use crate::live::LiveFrame;
+use crate::live::{LiveFrame, LiveTrustConfig};
 use crate::runtime::{build_run, RunData};
 use crate::source::{
     banner_for, spawn_ingest, BannerState, LiveState, SourceMode, DEFAULT_POLL_MS,
@@ -56,6 +58,9 @@ pub struct ViewerConfig {
     pub source: SourceMode,
     /// Upstream poll interval (ms) for the `/api/field` fallback — live only.
     pub poll_ms: u64,
+    /// Required trust policy and sensor registry for live ingestion. Synthetic
+    /// mode does not use this field.
+    pub live_trust: Option<LiveTrustConfig>,
 }
 
 impl Default for ViewerConfig {
@@ -67,6 +72,37 @@ impl Default for ViewerConfig {
             // Default stays SYNTHETIC — never live by default.
             source: SourceMode::Synthetic,
             poll_ms: DEFAULT_POLL_MS,
+            live_trust: None,
+        }
+    }
+}
+
+/// Fail-closed viewer startup error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ViewerConfigError {
+    /// Live source selected without independent trust configuration.
+    MissingLiveTrust,
+    /// Live trust configuration was invalid or attempted simulation mode.
+    InvalidLiveTrust(rufield_provenance::TrustError),
+}
+
+impl std::fmt::Display for ViewerConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingLiveTrust => write!(
+                f,
+                "live source requires an explicit trust policy and sensor key registry"
+            ),
+            Self::InvalidLiveTrust(error) => write!(f, "invalid live trust configuration: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ViewerConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidLiveTrust(error) => Some(error),
+            Self::MissingLiveTrust => None,
         }
     }
 }
@@ -96,12 +132,19 @@ impl AppState {
 /// In [`SourceMode::Live`] this also spawns the background ingest task (it must
 /// therefore be called from within a Tokio runtime, which the binary and the
 /// `#[tokio::test]` harness both provide).
-pub fn app(config: ViewerConfig) -> Router {
+pub fn app(config: ViewerConfig) -> Result<Router, ViewerConfigError> {
     let (live, live_tx) = match &config.source {
         SourceMode::Synthetic => (None, None),
         SourceMode::Live { upstream } => {
+            let trust = config
+                .live_trust
+                .clone()
+                .ok_or(ViewerConfigError::MissingLiveTrust)?;
+            let processor = trust
+                .into_processor()
+                .map_err(ViewerConfigError::InvalidLiveTrust)?;
             let state = Arc::new(LiveState::new(upstream.clone()));
-            let tx = spawn_ingest(state.clone(), config.poll_ms);
+            let tx = spawn_ingest(state.clone(), config.poll_ms, processor);
             (Some(state), Some(tx))
         }
     };
@@ -110,19 +153,21 @@ pub fn app(config: ViewerConfig) -> Router {
         live,
         live_tx,
     });
-    Router::new()
+    Ok(Router::new()
         .route("/", get(index))
         .route("/app.js", get(app_js))
         .route("/health", get(health))
         .route("/api/source", get(api_source))
         .route("/api/run", get(api_run))
         .route("/events", get(events))
-        .with_state(state)
+        .with_state(state))
 }
 
-/// Build the router **without** spawning any background task. Used by the
-/// live-mode tests so they can assert config/banner state synchronously without
-/// requiring a reachable upstream.
+/// Test-only router builder that spawns no background ingest task.
+///
+/// This intentionally bypasses live trust validation because no event can be
+/// ingested. It exists only for synchronous banner and route tests and must not
+/// be used to serve a deployment.
 pub fn app_no_ingest(config: ViewerConfig) -> Router {
     let live = match &config.source {
         SourceMode::Synthetic => None,
@@ -156,6 +201,7 @@ async fn app_js() -> impl IntoResponse {
 
 async fn health(State(st): State<Arc<AppState>>) -> impl IntoResponse {
     let banner = st.banner();
+    let trust_mode = st.config.live_trust.as_ref().map(|trust| trust.policy.mode);
     Json(serde_json::json!({
         "status": "ok",
         "spec_version": rufield_core::SPEC_VERSION,
@@ -163,6 +209,7 @@ async fn health(State(st): State<Arc<AppState>>) -> impl IntoResponse {
         "synthetic": st.config.source.is_synthetic(),
         "source": st.config.source.code(),
         "upstream": st.config.source.upstream(),
+        "trust_mode": trust_mode,
         "banner": banner,
         "banner_label": banner.label(),
         "seed": st.config.seed,
@@ -175,9 +222,11 @@ async fn health(State(st): State<Arc<AppState>>) -> impl IntoResponse {
 /// DISCONNECTED) banner; it is the single source of truth for banner honesty.
 async fn api_source(State(st): State<Arc<AppState>>) -> impl IntoResponse {
     let banner = st.banner();
+    let trust_mode = st.config.live_trust.as_ref().map(|trust| trust.policy.mode);
     Json(serde_json::json!({
         "source": st.config.source.code(),
         "upstream": st.config.source.upstream(),
+        "trust_mode": trust_mode,
         "synthetic": st.config.source.is_synthetic(),
         "banner": banner,
         "banner_label": banner.label(),
@@ -221,8 +270,9 @@ async fn api_run(
 /// - **Synthetic** mode: replay the deterministic synthetic run, paced at
 ///   `tick_ms`, emitting `meta` → `frame`* → `done` (looping unless `--no-loop`).
 /// - **Live** mode: emit a `meta` frame announcing the LIVE/DISCONNECTED banner,
-///   then forward each ingested upstream [`LiveFrame`] as a `frame` event as it
-///   arrives. There is no `done` (a live feed does not end).
+///   then forward each privacy-guarded public [`LiveFrame`] as a `frame` event.
+///   Raw upstream events never enter this channel. There is no `done` because a
+///   live feed does not end.
 async fn events(
     State(st): State<Arc<AppState>>,
     Query(params): Query<RunParams>,
@@ -375,6 +425,11 @@ impl tokio_stream::Stream for PayloadStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::live::{
+        LiveEventDetails, LiveEventView, LivePrivacyDisposition, LiveTickFrame,
+        LiveTrustDecisionView, LiveTrustRejectionCode,
+    };
+    use http_body_util::BodyExt;
 
     #[test]
     fn config_defaults_are_sane() {
@@ -382,5 +437,78 @@ mod tests {
         assert_eq!(c.seed, 2026);
         assert!(c.tick_ms >= 1);
         assert!(c.loop_stream);
+        assert!(c.live_trust.is_none());
+    }
+
+    #[tokio::test]
+    async fn live_http_sse_contains_diagnostics_but_no_sensitive_event_fields() {
+        let upstream = "http://127.0.0.1:8080";
+        let config = ViewerConfig {
+            source: SourceMode::Live {
+                upstream: upstream.into(),
+            },
+            ..ViewerConfig::default()
+        };
+        let live = Arc::new(LiveState::new(upstream));
+        let state = Arc::new(AppState {
+            config,
+            live: Some(live),
+            live_tx: None,
+        });
+        let (tx, _rx) = broadcast::channel(4);
+        let stream = live_event_stream(state, tx.clone()).take(2);
+
+        tx.send(LiveFrame {
+            frame: LiveTickFrame {
+                tick: 7,
+                events: vec![LiveEventView {
+                    sequence: 0,
+                    privacy: rufield_core::PrivacyClass::P2.into(),
+                    trust: LiveTrustDecisionView {
+                        accepted: false,
+                        rejection_code: Some(LiveTrustRejectionCode::UnknownKey),
+                    },
+                    privacy_disposition: LivePrivacyDisposition::Allowed,
+                    details: Some(LiveEventDetails {
+                        modality: "wifi_csi",
+                        modality_label: "WiFi CSI",
+                        confidence: 0.8,
+                    }),
+                }],
+                inferences: Vec::new(),
+            },
+            verified_count: 0,
+            unverified_count: 1,
+            privacy_redacted_count: 0,
+            privacy_redacted_inference_count: 0,
+        })
+        .unwrap();
+
+        let response = Sse::new(stream).into_response();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+
+        assert!(body.contains("unknown_key"));
+        assert!(body.contains("unverified_count"));
+        for forbidden_key in [
+            "event_id",
+            "device_id",
+            "zone_id",
+            "truth_labels",
+            "receipt",
+            "raw_hash",
+            "firmware_hash",
+            "signer_pubkey_hex",
+            "signature_hex",
+            "supporting_events",
+            "contradicting_events",
+            "model_id",
+            "calibration_id",
+        ] {
+            assert!(
+                !body.contains(&format!("\"{forbidden_key}\"")),
+                "SSE exposed forbidden field {forbidden_key}: {body}"
+            );
+        }
     }
 }

--- a/crates/rufield-viewer/src/source.rs
+++ b/crates/rufield-viewer/src/source.rs
@@ -1,5 +1,5 @@
 //! The viewer's **data source selector** and the live-ingest runtime
-//! (ADR-260 §27.9 + ADR-262 P3).
+//! (ADR-260 §27.9 and ADR-261 trust policy; ADR-262 P3 transport).
 //!
 //! The viewer can be driven from one of two sources:
 //!
@@ -7,8 +7,8 @@
 //!   `SyntheticSim → RuFieldFusion` pipeline. Banner: `SYNTHETIC`.
 //! - [`SourceMode::Live`] — consumes **real** `rufield_core::FieldEvent`s from
 //!   an external upstream (RuView's `/ws/field` / `/api/field`, ADR-262 P3),
-//!   verifies each event's provenance receipt on ingest, and feeds the verified
-//!   events through the *same* fusion/inference display path. Banner: `LIVE`
+//!   authorizes each event through an injected production trust registry, and
+//!   feeds accepted events through a persistent production fusion engine. Banner: `LIVE`
 //!   when connected, `DISCONNECTED` when the upstream is unreachable.
 //!
 //! ## Banner honesty (the whole point)
@@ -28,12 +28,12 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 use tokio::sync::broadcast;
 
-use crate::live::{frame_from_api_payload, frame_from_ws_event, LiveFrame};
+use crate::live::{frame_from_api_payload, frame_from_ws_event, LiveFrame, LiveProcessor};
 
 /// Default upstream poll interval (ms) when subscribing the `/api/field` ring.
 pub const DEFAULT_POLL_MS: u64 = 500;
@@ -90,7 +90,7 @@ impl SourceMode {
 pub enum BannerState {
     /// `SYNTHETIC — simulated sensors, no hardware`.
     Synthetic,
-    /// `LIVE — <upstream>` (real upstream events, receipt-verified).
+    /// `LIVE — <upstream>` (real upstream events, policy-authorized).
     Live {
         /// The upstream base URL.
         upstream: String,
@@ -180,23 +180,39 @@ pub fn banner_for(mode: &SourceMode, live: Option<&LiveState>) -> BannerState {
 /// Spawn the background live-ingest task. It tries the `/ws/field` SSE stream
 /// first (preferred — one event per cycle, push); if that cannot be opened it
 /// falls back to polling `/api/field` on [`DEFAULT_POLL_MS`]. Each decoded batch
-/// becomes a [`LiveFrame`] (with on-ingest receipt verification) and is
-/// broadcast to all connected dashboards. Connectivity is reflected into
-/// `state` so the banner can show LIVE vs DISCONNECTED honestly.
+/// becomes a [`LiveFrame`] after trust authorization and fail-closed privacy
+/// projection, then is broadcast to connected dashboards. Raw upstream events
+/// never enter the broadcast channel. Connectivity is reflected into `state`
+/// so the banner can show LIVE vs DISCONNECTED honestly.
+///
+/// Replay watermarks remain in this task-owned processor across reconnects.
+/// Surviving a viewer process restart additionally requires the host to export
+/// replay state atomically and inject it through [`crate::live::LiveTrustConfig`]
+/// before this task starts. The reference binary does not yet provide that
+/// durable storage adapter.
 ///
 /// Returns the broadcast receiver factory (via the returned `Sender`).
-pub fn spawn_ingest(state: Arc<LiveState>, poll_ms: u64) -> broadcast::Sender<LiveFrame> {
+pub fn spawn_ingest(
+    state: Arc<LiveState>,
+    poll_ms: u64,
+    processor: LiveProcessor,
+) -> broadcast::Sender<LiveFrame> {
     let (tx, _rx) = broadcast::channel::<LiveFrame>(256);
     let tx_task = tx.clone();
     tokio::spawn(async move {
-        ingest_loop(state, poll_ms.max(1), tx_task).await;
+        ingest_loop(state, poll_ms.max(1), tx_task, processor).await;
     });
     tx
 }
 
 /// The ingest loop: prefer `/ws/field` SSE, fall back to `/api/field` polling,
 /// retrying forever with a short backoff and keeping `state.connected` honest.
-async fn ingest_loop(state: Arc<LiveState>, poll_ms: u64, tx: broadcast::Sender<LiveFrame>) {
+async fn ingest_loop(
+    state: Arc<LiveState>,
+    poll_ms: u64,
+    tx: broadcast::Sender<LiveFrame>,
+    mut processor: LiveProcessor,
+) {
     let client = match reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
@@ -210,14 +226,14 @@ async fn ingest_loop(state: Arc<LiveState>, poll_ms: u64, tx: broadcast::Sender<
 
     loop {
         // Prefer the push stream. If it opens, consume it until it ends/errors.
-        match stream_ws(&client, &ws_url, &state, &tx, &mut tick).await {
+        match stream_ws(&client, &ws_url, &state, &tx, &mut tick, &mut processor).await {
             Ok(consumed) if consumed > 0 => {
                 // Stream ended after delivering frames; loop and reconnect.
                 continue;
             }
             _ => {
                 // SSE not available — fall back to polling the ring once.
-                if poll_api_once(&client, &api_url, &state, &tx, &mut tick).await {
+                if poll_api_once(&client, &api_url, &state, &tx, &mut tick, &mut processor).await {
                     // Connected via poll; pace before the next poll.
                 } else {
                     state.set_connected(false);
@@ -237,6 +253,7 @@ async fn stream_ws(
     state: &LiveState,
     tx: &broadcast::Sender<LiveFrame>,
     tick: &mut usize,
+    processor: &mut LiveProcessor,
 ) -> Result<usize, ()> {
     use futures_util::StreamExt;
 
@@ -260,7 +277,7 @@ async fn stream_ws(
             let raw = buf[..pos].to_string();
             buf.drain(..pos + 2);
             if let Some(data) = parse_sse_data(&raw) {
-                if let Ok(frame) = frame_from_ws_event(*tick, &data) {
+                if let Ok(frame) = frame_from_ws_event(processor, *tick, &data, unix_now_ns()) {
                     *tick += 1;
                     delivered += 1;
                     let _ = tx.send(frame);
@@ -299,6 +316,7 @@ async fn poll_api_once(
     state: &LiveState,
     tx: &broadcast::Sender<LiveFrame>,
     tick: &mut usize,
+    processor: &mut LiveProcessor,
 ) -> bool {
     let body = match client.get(url).send().await {
         Ok(r) if r.status().is_success() => match r.text().await {
@@ -307,7 +325,7 @@ async fn poll_api_once(
         },
         _ => return false,
     };
-    match frame_from_api_payload(*tick, &body) {
+    match frame_from_api_payload(processor, *tick, &body, unix_now_ns()) {
         Ok(frame) => {
             *tick += 1;
             state.set_connected(true);
@@ -321,6 +339,13 @@ async fn poll_api_once(
             false
         }
     }
+}
+
+fn unix_now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/crates/rufield-viewer/static/app.js
+++ b/crates/rufield-viewer/static/app.js
@@ -9,7 +9,8 @@
 //
 // The banner is honest by construction: it is set from /api/source (SYNTHETIC /
 // LIVE / DISCONNECTED) and the SSE `meta` event, so it always matches the data
-// actually being displayed. Live mode renders ONLY receipt-verified events.
+// actually being displayed. Live mode fuses ONLY events accepted by the
+// independently configured sensor trust policy.
 
 "use strict";
 
@@ -39,7 +40,7 @@ function setStatus(state, text) {
 // Drives the persistent banner from the server's single source of truth. The
 // three states are visually distinct and never interchangeable:
 //   synthetic    → amber "SYNTHETIC — simulated sensors, no hardware"
-//   live         → green  "LIVE — <upstream>"  (real, receipt-verified)
+//   live         → green  "LIVE — <upstream>"  (real, policy-authorized)
 //   disconnected → red    "DISCONNECTED — <upstream> unreachable"
 let SOURCE = "synthetic";
 function applyBanner(banner) {
@@ -52,7 +53,7 @@ function applyBanner(banner) {
     b.textContent =
       "⚠ SYNTHETIC — simulated sensors, no hardware. Every signal below is a deterministic simulator replay, not a live sensor.";
   } else if (state === "live") {
-    b.textContent = `● ${label} — REAL upstream FieldEvents, receipt-verified on ingest. No camera, no identity.`;
+    b.textContent = `● ${label} — REAL upstream FieldEvents, enrolled sensor trust enforced on ingest. No camera, no identity.`;
   } else {
     b.textContent = `✕ ${label}. Live source selected but no events received — NOT falling back to synthetic.`;
   }
@@ -107,28 +108,40 @@ const prettyLabel = (l) =>
 function appendEvents(events) {
   const log = $("event-log");
   for (const ev of events) {
-    EVENTS.set(ev.event_id, ev);
-    const truth = ev.truth_labels.length
-      ? `<div class="truth"><b>truth:</b> ${ev.truth_labels.map(esc).join(", ")}</div>`
-      : `<div class="truth">truth: (empty room)</div>`;
+    const isLive = !!ev.trust;
+    if (!isLive) EVENTS.set(ev.event_id, ev);
+    const accepted = isLive ? ev.trust.accepted : !!(ev.receipt && ev.receipt.verified);
+    const details = isLive ? ev.details : ev;
+    const modality = details ? details.modality : "redacted";
+    const modalityLabel = details ? details.modality_label : "Details redacted";
+    const displayId = isLive ? `live event ${ev.sequence + 1}` : ev.event_id;
+    const diagnostic = isLive
+      ? (accepted
+          ? `trust accepted · privacy ${ev.privacy_disposition}`
+          : `trust rejected · ${prettyLabel(ev.trust.rejection_code || "policy_rejected")} · privacy ${ev.privacy_disposition}`)
+      : (ev.truth_labels.length
+          ? `<b>truth:</b> ${ev.truth_labels.map(esc).join(", ")}`
+          : "truth: (empty room)");
     const node = el("div", "ev");
-    node.dataset.eid = ev.event_id;
-    // Per-event verified ✓/✗ badge. Unverified (forged/tampered) events are
+    if (!isLive) node.dataset.eid = ev.event_id;
+    // Per-event accepted ✓/✗ badge. Rejected events are
     // shown but visibly flagged — they are NOT fused into trusted inferences.
-    const verified = ev.receipt && ev.receipt.verified;
-    const vbadge = verified
-      ? `<span class="verify-ok" title="provenance receipt verified">✓</span>`
-      : `<span class="verify-bad" title="receipt NOT verified — flagged, not fused">✗ unverified</span>`;
-    if (!verified) node.classList.add("ev-unverified");
+    const vbadge = accepted
+      ? `<span class="verify-ok" title="sensor trust policy accepted">✓</span>`
+      : `<span class="verify-bad" title="trust policy rejected — flagged, not fused">✗ rejected</span>`;
+    if (!accepted) node.classList.add("ev-unverified");
+    const confidence = details
+      ? `<span class="conf">conf ${(details.confidence * 100).toFixed(0)}%</span>`
+      : `<span class="conf">redacted</span>`;
     node.innerHTML =
       `<div class="row1">` +
       vbadge +
-      modTag(ev.modality, ev.modality_label) +
+      modTag(modality, modalityLabel) +
       pcBadge(ev.privacy) +
-      `<span class="eid">${esc(ev.event_id)}</span>` +
-      `<span class="conf">conf ${(ev.confidence * 100).toFixed(0)}%</span>` +
-      `</div>` + truth;
-    node.addEventListener("click", () => openReceipt(ev.event_id));
+      `<span class="eid">${esc(displayId)}</span>` +
+      confidence +
+      `</div><div class="truth">${isLive ? esc(diagnostic) : diagnostic}</div>`;
+    if (!isLive) node.addEventListener("click", () => openReceipt(ev.event_id));
     log.prepend(node);
   }
   // Cap DOM size so a long-running loop does not grow unbounded.
@@ -145,16 +158,19 @@ function renderGraph(inferences) {
   }
   for (const inf of inferences) {
     const node = el("div", "inf");
-    const sup = inf.supporting_events.length
-      ? `supports → ${inf.supporting_events.map((e) => `<code>${esc(short(e))}</code>`).join(" ")}`
-      : "supports → (none)";
-    const con = inf.contradicting_events.length
+    const supporting = inf.supporting_events || [];
+    const contradicting = inf.contradicting_events || [];
+    const sup = supporting.length
+      ? `supports → ${supporting.map((e) => `<code>${esc(short(e))}</code>`).join(" ")}`
+      : (SOURCE === "live" ? "provenance edges retained server-side" : "supports → (none)");
+    const con = contradicting.length
       ? `<span class="contra">contradicts → ${inf.contradicting_events.map((e) => `<code>${esc(short(e))}</code>`).join(" ")}</span>`
       : "";
+    const model = inf.model_id ? `${esc(inf.model_id)} · ` : "";
     node.innerHTML =
       `<div class="head"><span class="name">${esc(prettyLabel(inf.label))}</span>` +
       pcBadge(inf.privacy) +
-      `<span class="model">${esc(inf.model_id)} · ${(inf.confidence * 100).toFixed(0)}%</span></div>` +
+      `<span class="model">${model}${(inf.confidence * 100).toFixed(0)}%</span></div>` +
       `<div class="edges">${sup}${con ? "<br>" + con : ""}</div>`;
     g.appendChild(node);
   }
@@ -192,13 +208,15 @@ function renderLiveMeta(meta) {
 }
 
 // Update the integrity panel from a live frame's verification counters.
-function renderLiveIntegrity(verified, unverified) {
+function renderLiveIntegrity(verified, unverified, redactedEvents, redactedInferences) {
   const grid = $("meta-grid");
   const unvClass = unverified === 0 ? "good" : "bad";
   const stats = [
     ["source", "LIVE", "good"],
     ["verified events", verified, "good"],
     ["unverified (flagged, not fused)", unverified, unvClass],
+    ["privacy-redacted event details", redactedEvents || 0, ""],
+    ["privacy-redacted inferences", redactedInferences || 0, ""],
   ];
   grid.innerHTML = "";
   for (const [k, v, cls] of stats) {
@@ -217,14 +235,14 @@ function openReceipt(eventId) {
   $("modal-sub").innerHTML =
     `${modTag(ev.modality, ev.modality_label)} ${pcBadge(ev.privacy)} <span class="eid">${esc(ev.event_id)}</span>`;
   const verified = r.verified
-    ? `<span class="verify-ok">✓ verified</span>`
-    : `<span class="verify-bad">✗ NOT verified</span>`;
+    ? `<span class="verify-ok">✓ policy accepted</span>`
+    : `<span class="verify-bad">✗ policy rejected</span>`;
   const fusable = r.fusable
-    ? `<span class="verify-ok">✓ fusable (§11)</span>`
-    : `<span class="verify-bad">✗ not fusable</span>`;
+    ? `<span class="verify-ok">✓ accepted for fusion</span>`
+    : `<span class="verify-bad">✗ rejected from fusion</span>`;
   const rows = [
-    ["signature", verified],
-    ["fusability", fusable],
+    ["trust decision", verified],
+    ["fusion decision", fusable],
     ["synthetic", r.synthetic ? "true (simulator-flagged)" : "false"],
     ["raw hash", esc(r.raw_hash)],
     ["firmware hash", esc(r.firmware_hash)],
@@ -265,7 +283,12 @@ function connect() {
     renderRoomState(f.inferences);
     renderGraph(f.inferences);
     if (payload.frame) {
-      renderLiveIntegrity(payload.verified_count, payload.unverified_count);
+      renderLiveIntegrity(
+        payload.verified_count,
+        payload.unverified_count,
+        payload.privacy_redacted_count,
+        payload.privacy_redacted_inference_count,
+      );
       setStatus("live", "live · receiving upstream events");
     }
   });

--- a/crates/rufield-viewer/static/index.html
+++ b/crates/rufield-viewer/static/index.html
@@ -38,7 +38,7 @@
       background: repeating-linear-gradient(45deg, #3a2a00, #3a2a00 12px, #2e2200 12px, #2e2200 24px);
       color: #ffd874; border-bottom-color: var(--warn);
     }
-    /* LIVE: solid green — real, receipt-verified upstream events. */
+    /* LIVE: solid green — real, policy-authorized upstream events. */
     #source-banner[data-state="live"] {
       background: #0c2e16; color: #6fe08a; border-bottom-color: var(--good);
     }

--- a/crates/rufield-viewer/tests/http.rs
+++ b/crates/rufield-viewer/tests/http.rs
@@ -11,7 +11,7 @@ use rufield_viewer::{app, app_no_ingest, SourceMode, ViewerConfig};
 use tower::ServiceExt;
 
 async fn get(path: &str) -> (StatusCode, String) {
-    let router = app(ViewerConfig::default());
+    let router = app(ViewerConfig::default()).unwrap();
     let resp = router
         .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
         .await
@@ -135,7 +135,8 @@ async fn events_stream_emits_meta_then_frames_in_order() {
         tick_ms: 1,
         loop_stream: false,
         ..ViewerConfig::default()
-    });
+    })
+    .unwrap();
     let resp = router
         .oneshot(
             Request::builder()
@@ -161,7 +162,8 @@ async fn events_stream_emits_meta_then_frames_in_order() {
         tick_ms: 1,
         loop_stream: false,
         ..ViewerConfig::default()
-    });
+    })
+    .unwrap();
     let resp2 = router2
         .oneshot(
             Request::builder()
@@ -179,8 +181,9 @@ async fn events_stream_emits_meta_then_frames_in_order() {
 }
 
 // ---------------------------------------------------------------------------
-// Live-ingest mode (ADR-262 P3). No real RuView upstream runs in this env, so
-// these use `app_no_ingest` to assert the config/banner contract synchronously.
+// Live-ingest trust (ADR-261; external ADR-262 P3 transport). No real RuView
+// upstream runs in this env, so these use `app_no_ingest` to assert the
+// config/banner contract synchronously.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -208,6 +211,14 @@ async fn live_source_reports_live_not_synthetic() {
         !label.contains("SYNTHETIC"),
         "live mode must never show SYNTHETIC"
     );
+}
+
+#[tokio::test]
+async fn live_app_fails_closed_without_trust_registry() {
+    assert!(matches!(
+        app(live_config()),
+        Err(rufield_viewer::ViewerConfigError::MissingLiveTrust)
+    ));
 }
 
 #[tokio::test]

--- a/docs/ADR-260-rufield-mfs.md
+++ b/docs/ADR-260-rufield-mfs.md
@@ -172,7 +172,9 @@ Default system policy: edge storage may retain P0 only temporarily; network tran
 
 ## 11. Provenance Receipt
 
-Every event must be auditable (`ProvenanceReceipt`). Acceptance invariant: **No fused inference is valid unless every contributing event has a provenance receipt or is explicitly marked synthetic.**
+Every event must be auditable (`ProvenanceReceipt`). The original simulation acceptance invariant is: **No fused inference is valid unless every contributing event has a provenance receipt or is explicitly marked synthetic.**
+
+ADR-261 narrows that compatibility rule to simulation. Captured replay and production reject synthetic evidence and require every event key to be independently enrolled, bound to the claimed sensor and nonrevoked before its signature, freshness and replay position are accepted.
 
 ## 12. Fusion Graph
 
@@ -249,8 +251,8 @@ Decision: **Create open RuField spec plus reference stack.** It maximizes credib
 | ----------------------------------- | ------------------------------- | -------------------------------------- |
 | Raw waveform leakage                | privacy breach                  | P0 edge only by default                |
 | Biometric inference without consent | legal and trust risk            | P4 consent gate                        |
-| Sensor spoofing                     | false occupancy or safety event | signed sensor receipts                 |
-| Replay attack                       | forged event stream             | nonce plus timestamp plus hash chain   |
+| Sensor spoofing                     | false occupancy or safety event | independently enrolled sensor-key binding plus signed receipts (ADR-261) |
+| Replay attack                       | forged event stream             | monotonic, persistable per-sensor replay watermarks (ADR-261) |
 | Model drift                         | wrong inference                 | calibration expiry and benchmark gates |
 | Overfitting to one room             | weak generalization             | room split benchmark                   |
 | Vendor firmware change              | silent degradation              | firmware hash in receipt               |
@@ -363,26 +365,15 @@ known truth and runs within latency/privacy/provenance budgets — they are
 | Crate | Implements |
 |-------|-----------|
 | `rufield-core` | §7/§9/§16/§20 data model: `Modality` (15), `FieldAxis`, `FieldTensor` (shape↔values validated), `PrivacyClass` (P0–P5), `SensorDescriptor`, `Observation`, `FieldEvent`, `CalibrationReceipt`, `InferenceQuery`, `FieldInference`, `FieldEmbedding`; `FieldAdapter`/`FieldEncoder`/`FusionEngine`/`PrivacyGuard` traits. §7 JSON example round-trips. |
-| `rufield-provenance` | Real `sha256` content hashing + deterministic `ed25519` sign/verify; §11 `is_fusable` invariant. Tests: tamper → verify fails; synthetic event fusable without signer. |
+| `rufield-provenance` | Real `sha256` content hashing + deterministic `ed25519` sign/verify. ADR-261 `TrustVerifier` provides explicit simulation, captured-replay and production policies; independent sensor-key enrollment, revocation, binding, freshness and replay checks; and serializable replay state. `is_fusable` remains a simulation-only compatibility helper. |
 | `rufield-privacy` | §10 default policy + `DefaultPrivacyGuard` (`authorize` → Allow/Deny/RequiresConsent). Tests: P0 transmit denied; P4 no-consent → RequiresConsent; P4 consent → Allow; P2 → Allow; P5 needs identity binding. |
 | `rufield-adapters` | Deterministic seeded `SyntheticSim` emitting the §19 sequence across 3 modalities (wifi_csi, mmwave_radar, infrared_thermal); same seed ⇒ identical signed event stream with ground-truth labels. **Plus `CsiReplayAdapter`** — the first **real (non-synthetic)** adapter: parses real captured WiFi CSI from `.csi.jsonl`, calibrates an empty-room baseline, emits signed `FieldEvent`s with a CSI-variance motion/presence proxy (replay from file, unlabeled — NOT validated accuracy). |
 | `rufield-fusion` | `FusionGraph` (§12) + `RuFieldFusion` engine; TOML rules (§13, ≥5 inferences: person_present, sitting, sleeping, breathing, nocturnal_scratch, bed_exit, room_transition); weighted-Bayes + temporal-window; rejects non-fusable events; `FieldInference` with §24 fields. |
 | `rufield-bench` | Deterministic runner: F1 per task (SYNTHETIC), p95 latency, provenance coverage, privacy violations; JSON + human table; §31 acceptance test as `#[test]`. |
-| `rufield-viewer` | §14 Layer 7 / §27.9 read-only web dashboard (Axum + vanilla JS, no build step). **Two sources** (`--source synthetic` default, or `--source live --upstream <URL>`): SYNTHETIC drives `SyntheticSim → RuFieldFusion`; LIVE ingests real `FieldEvent`s from an external RuField upstream (RuView `/ws/field` / `/api/field`, **ADR-262 P3**) — preferring the `/ws/field` SSE stream, falling back to polling `/api/field` — verifying each event's provenance receipt **on ingest** (`is_fusable`) and feeding only verified events through the same fusion/inference display path (unverified events are flagged ✗ and never fused). Serves `GET /` (page), `GET /events` (SSE), `GET /api/source` (source + banner state), `GET /api/run` (deterministic JSON; 409 in live mode), `GET /health`. Panels (identical across sources): live room state, event log with modality + P0–P5 privacy badges + verified ✓/✗ badge, fusion graph, signed-receipt viewer. **Banner honesty:** `SYNTHETIC` (amber) / `LIVE — <upstream>` (green, connected) / `DISCONNECTED — <upstream> unreachable` (red) — mutually exclusive, never mislabeled, no silent synthetic fallback in live mode. Tests assert the synthetic banner is present, `/api/run` is deterministic with ≥1 event/modality (each with privacy class + receipt) and ≥5 inferences, the SSE order is deterministic, the live source reports LIVE-not-SYNTHETIC with the upstream URL, the ingest deserializer verifies a real signed `/api/field` payload and renders it while a tampered event is flagged unverified-and-not-fused. |
+| `rufield-viewer` | §14 Layer 7 / §27.9 read-only web dashboard (Axum + vanilla JS, no build step). **Two sources** (`--source synthetic` default, or `--source live --upstream <URL>`): SYNTHETIC drives `SyntheticSim → RuFieldFusion`; LIVE ingests real `FieldEvent`s over the external RuView `/ws/field` / `/api/field` transport (**ADR-262 P3**). Per ADR-261, live startup requires an independently enrolled sensor-key registry and a production or captured-replay policy. The persistent live processor rejects synthetic events, unknown self-signed keys, revoked keys, binding mismatches, malformed signatures and replay before fusion mutation; production also rejects stale/future timestamps. Before broadcast, a default network privacy guard creates a fail-closed public projection. Live SSE never contains upstream event/device/zone ids, raw labels, hashes, signer keys, signatures, model/calibration ids, or provenance edges; rejected input is represented only by stable non-identifying reason codes. P0, P3, P4 and P5 details are withheld by default. Replay state survives batches and reconnects within one process. The reference binary accepts programmatic restore but does not yet atomically persist updated watermarks across process restart. Banner states remain mutually exclusive: `SYNTHETIC`, `LIVE — <upstream>`, or `DISCONNECTED — <upstream> unreachable`, with no synthetic fallback in live mode. |
 
-Total test count across the workspace: **0 failed**. Per-crate (verified): core
-12, provenance 6, privacy 7, `rufield-adapters` 25 lib + 3 integration (the new
-`CsiReplayAdapter` real-CSI tests), `rufield-fusion` 3, bench 12, viewer 12.
-`cargo clippy -p rufield-adapters` is clean.
-
-> Environmental note: on this Windows box, Windows Defender intermittently
-> blocks execution of a freshly-rebuilt test binary (`os error 5`, "Access is
-> denied"), which can abort the aggregate run for an individual crate's
-> *unittest exe* (observed for `rufield-fusion` after a rebuild). It is an
-> environmental exec-block, not a code failure — the crate compiles clean, and
-> the real-CSI → fusion path is exercised and **green** through the
-> `rufield-adapters` integration test (`csi_replay_fusion`), which drives
-> `RuFieldFusion::ingest`/`infer` over the 199-frame real-CSI fixture.
+Workspace verification after ADR-261 integration: **130 passed, 0 failed** with
+`cargo test --workspace`.
 
 ### §27 acceptance-criteria scorecard
 
@@ -396,17 +387,15 @@ Total test count across the workspace: **0 failed**. Per-crate (verified): core
 | 6 | Benchmark runner produces deterministic reports | **PASS** — identical report across runs (latency is the only wall-clock field) |
 | 7 | Raw waveform storage disabled by default | **PASS** — P0 network transmission denied by default policy |
 | 8 | P4 inference requires consent policy approval | **PASS** — P4 without consent → RequiresConsent; breathing/scratch rules carry `requires_consent = true` |
-| 9 | Dashboard shows live camera-free room intelligence | **PASS** — `rufield-viewer` (Axum + vanilla JS, no build step) drives the `SyntheticSim → RuFieldFusion` pipeline and streams it to a single-page dashboard over SSE (`/events`) + JSON (`/api/run`): live room state, event log with modality + privacy-class (P0–P5) badges, fusion graph (supporting/contradicting edges), and a signed provenance-receipt viewer. It is a **read-only SYNTHETIC viewer** (persistent `SYNTHETIC — simulated sensors, no hardware` banner), **not** a device-management console; fleet/real-adapter device management is a separate later milestone. |
+| 9 | Dashboard shows live camera-free room intelligence | **PASS** — `rufield-viewer` supports an explicitly labeled synthetic demo plus a fail-closed live source. Live transport is RuView `/ws/field` / `/api/field` (ADR-262 P3); live trust is ADR-261 with an independently enrolled registry and production or captured-replay policy. Synthetic and unknown self-signed events cannot mutate live fusion. The live SSE projection applies the default network privacy guard and contains no upstream direct identifiers, raw labels, receipt material, signatures, or provenance edges. A persistent processor retains replay watermarks across batches and reconnects, but the reference binary still needs an atomic storage adapter for restart persistence. The viewer remains read-only and is not a device-management console. |
 | 10 | Spec readable for external implementers | **PASS** — ADR-260 + detailed standalone README with compiling usage examples |
 
-**Decision:** all §27 criteria 1–10 now PASS. Criterion 9 (live dashboard) was
-previously deferred; it is satisfied by `rufield-viewer`, a read-only SYNTHETIC
-dashboard that streams the §19 camera-free room-intelligence demo (room state +
-privacy-class badges + fusion graph + signed-receipt viewer) over SSE/JSON.
-Status remains **Accepted — v0.1 reference stack** (now with the dashboard
-criterion met). Note the viewer is a demo viewer, not a device-management
-console — there are no real devices in v0.1; fleet/real-adapter management is a
-separate later milestone.
+**Decision:** all §27 criteria 1–10 now PASS. Criterion 9 is satisfied by
+`rufield-viewer`: a read-only dashboard with an explicitly labeled synthetic
+demo and a live upstream mode. The live source enforces ADR-261 trust before
+fusion and uses ADR-262 P3 only as its external RuView transport contract.
+Status remains **Accepted — v0.1 reference stack**. The viewer is not a
+device-management console; fleet management remains a separate milestone.
 
 ### Deterministic benchmark report (SYNTHETIC, seed = 2026)
 

--- a/docs/ADR-261-fail-closed-provenance-trust.md
+++ b/docs/ADR-261-fail-closed-provenance-trust.md
@@ -1,0 +1,210 @@
+# ADR 261: Fail Closed Provenance Trust and Replay Defense
+
+Status: Accepted
+
+Date: 2026 08 21
+
+Deciders: rUv, RuField maintainers
+
+Tags: provenance, trust, sensor identity, replay, STRIDE, production
+
+## 1. Context
+
+The original RuField MFS version 0.1 fusability rule accepted an event when it
+was marked synthetic or when its detached Ed25519 signature verified against
+the public key carried inside that same event.
+
+That rule is useful for deterministic simulation and integrity checks, but it
+does not authenticate a sensor. Any producer can create a key pair, sign its
+own event and provide the corresponding public key. Any producer can also set
+the unsigned synthetic flag. The stateless rule has no replay protection.
+
+Production fusion therefore needs an authorization decision above signature
+verification. The decision must be deterministic under test, persist across a
+restart and reject before the graph or inference window changes.
+
+## 2. Decision
+
+Introduce a stateful `TrustVerifier` in `rufield-provenance` and make
+`RuFieldFusion` own one verifier.
+
+The verifier has three explicit modes.
+
+| Mode | Synthetic evidence | Independent key enrollment | Freshness | Replay watermark |
+| --- | --- | --- | --- | --- |
+| `Simulation` | Allowed | Not required | Not checked | Enforced |
+| `CapturedReplay` | Rejected | Required | Historical time allowed | Enforced |
+| `Production` | Rejected | Required | Required | Enforced |
+
+`Simulation` is the only compatibility boundary for the original
+`is_fusable` behavior. `is_fusable` remains public for existing benchmark and
+simulator callers, but its documentation forbids using it as a production
+authorization decision.
+
+`CapturedReplay` exists for real, signed recordings whose timestamps are
+necessarily outside a live freshness window. It is not a way to admit
+synthetic events or unknown keys.
+
+`Production` defaults to a maximum event age of five minutes and maximum future
+clock skew of five seconds. A caller may configure stricter values.
+
+## 3. Trust Anchors and Binding
+
+`TrustedKeyRegistry` is configured independently from event input. It maps a
+stable sensor id to a normalized Ed25519 public key and carries a revocation
+set.
+
+The event-carried public key is treated only as a claimed identifier. A live
+event is accepted only when all of these predicates are true.
+
+1. The event and sensor ids are nonempty.
+2. The event is not synthetic.
+3. The carried key is valid Ed25519 material.
+4. The key appears in the independent registry.
+5. The key is not revoked.
+6. The sensor id is enrolled.
+7. The sensor id is bound to that exact key.
+8. The signature verifies over the canonical event.
+9. The timestamp is inside the configured live window.
+10. The event timestamp strictly advances its sensor watermark.
+
+All checks precede replay watermark mutation. Only a fully accepted event can
+advance state. Fusion then records the sensor and event nodes and adds the
+event to its temporal window.
+
+## 4. Replay State
+
+Versioned `ReplayState` stores one `ReplayWatermark` per sensor. A watermark
+contains the last timestamp, event id and optional signer key.
+
+The state has strict JSON serialization and restoration. Restoration rejects
+unknown fields, unsupported schema versions, empty sensor ids, empty event ids,
+malformed signer keys, removed existing watermarks and timestamp rollback.
+
+The storage system must write this state atomically after accepted batches and
+integrity protect it. The library deliberately does not choose a database or
+key management service.
+
+## 5. STRIDE Analysis
+
+| Threat | Existing exposure | Control in this decision | Residual risk |
+| --- | --- | --- | --- |
+| Spoofing | Attacker self signs with an event-carried key or exploits noncanonical registry material | Validated normalized registry deserialization, independent key enrollment and sensor binding | Enrollment control plane compromise |
+| Tampering | Field values or synthetic flag modified after signing | Canonical signature covers event contents | Compromised sensor signing key |
+| Repudiation | No durable acceptance position | Persistable per-sensor watermark and signer identity | External audit receipt not yet implemented |
+| Information disclosure | Full accepted or rejected events and detailed trust errors can reveal device/zone ids, labels, hashes, signer material and enrollment status | The live viewer broadcasts a default-policy public projection with no direct identifiers, raw labels, receipt material, signatures or provenance edges; rejection diagnostics are closed stable enums without attacker-controlled text | Aggregate reason counts may still reveal fleet posture and require endpoint access control |
+| Denial of service | Invalid signatures consume verification work | Unknown and revoked keys reject before signature verification | Known-key signature flooding still consumes CPU |
+| Elevation of privilege | Synthetic flag bypasses all verification | Synthetic evidence is rejected outside simulation | A caller can still deliberately construct a simulation engine |
+
+## 6. API and Compatibility
+
+`RuFieldFusion::new` and `RuFieldFusion::with_rules` remain deterministic
+simulation constructors so existing benchmarks do not silently change.
+
+Live callers use `RuFieldFusion::production(registry)` or pass a verifier to
+`RuFieldFusion::with_trust_verifier`. Deterministic production tests use
+`ingest_at(event, now_ns)`. The trait `ingest` path uses system wall clock and
+still invokes the owned verifier.
+
+No event wire fields change in this decision. This keeps MFS version 0.1 input
+compatible and avoids modifying `rufield-core` during the security fix.
+
+## 7. Migration
+
+1. Inventory every caller of `is_fusable` and classify it as simulation,
+   captured replay or live production.
+2. Keep simulator and synthetic benchmark callers on `Simulation`.
+3. Provision a sensor-to-key registry from an authenticated control plane.
+4. Change historical real-data jobs to `CapturedReplay`.
+5. Change live services to `RuFieldFusion::production`.
+6. Persist `ReplayState` atomically and restore it before opening ingestion.
+7. Alert on unknown key, revocation, binding, freshness and replay rejection
+   counters without exposing enrollment details to untrusted clients.
+8. Remove direct live uses of `is_fusable` after downstream migration.
+
+The RuField viewer now implements steps 4, 5 and 8 at its ingest boundary. A
+single `LiveProcessor` retains the production or captured-replay verifier
+across upstream batches and reconnects. Live viewer startup requires explicit
+registry injection and rejects simulation mode.
+
+The viewer also applies `DefaultPrivacyGuard` before constructing its live
+broadcast projection. Raw `FieldEvent`s never enter the broadcast channel.
+P1/P2 output is restricted to whitelisted modality metadata and confidence;
+P0/P3/P4/P5 details are withheld without additional authorization. Direct
+identifiers, raw labels, hashes, signer keys, signatures, model/calibration ids
+and provenance edges are never members of the public live frame type. Trust
+failures are exposed only as stable enumerated reason codes.
+
+## 8. Rollback
+
+Operational rollback must fail closed.
+
+If trust configuration or replay storage fails, stop live fusion and retain
+the input for quarantine where privacy policy permits. Do not switch live
+traffic to `Simulation` and do not clear replay watermarks.
+
+The code can be rolled back only after disabling the live ingest endpoint. A
+rollback that restores the original production use of `is_fusable` reopens the
+self-signed and synthetic bypasses and is not an acceptable degraded mode.
+
+## 9. Consequences
+
+Benefits:
+
+1. A valid signature now proves both event integrity and an enrolled sensor
+   identity in captured replay and production.
+2. Replay rejection survives process restart when state is persisted.
+3. Simulation remains deterministic and backwards compatible.
+4. Typed rejection reasons support governance metrics and incident response.
+
+Costs:
+
+1. Production deployment now requires key enrollment, revocation distribution
+   and durable replay state.
+2. Every accepted event incurs one Ed25519 verification and one ordered-map
+   watermark lookup. At room-scale rates this should remain submillisecond, but
+   it requires a benchmark on target hardware.
+3. Operators must manage clock synchronization within the configured skew.
+
+## 10. Residual Risks and Follow Up
+
+The current event schema lacks a signed issuer key id, audience, stream epoch,
+explicit sequence number, nonce and attestation claims. Timestamp monotonicity
+is therefore the version 0.1 replay primitive. MFS version 0.2 should add these
+protected claims and define a COSE Sign1 profile aligned with RFC 9052 and an
+Entity Attestation Token profile aligned with RFC 9711.
+
+The trust registry and replay JSON are only as strong as their storage. A
+production adapter should bind them to hardware-backed keys or an equivalent
+managed key service and emit an append-only transparency receipt. SCITT, RFC
+9943, is a candidate interoperability profile.
+
+`RuFieldFusion::new` remains intentionally simulation scoped for compatibility.
+Repository policy should eventually lint any use of that constructor under a
+live feature or binary.
+
+The viewer accepts programmatically restored replay state, but its reference
+binary does not yet atomically export and persist updated watermarks. Replay
+defense therefore survives upstream reconnects within one process, but viewer
+restart protection requires a host storage adapter. Until that adapter exists,
+production operators must checkpoint `ReplayState` in an integrity-protected
+store or treat restart as a controlled trust-boundary reset.
+
+## 11. Acceptance Test
+
+Enroll one sensor key and submit one correctly signed fresh event. Confirm the
+event creates graph state. Then submit empty-identity, synthetic, flag-flipped,
+unknown self-signed, binding-mismatched, revoked, stale, future,
+malformed-signature, duplicate and nonmonotonic events. Confirm every case is
+rejected and neither the graph nor replay state changes. Deserialize an
+uppercase form of an enrolled key into the revocation set and confirm
+revocation still wins. Serialize the accepted watermark, restore it into a new
+process and confirm the original event is still rejected as a duplicate.
+
+Submit non-ASCII public-key and signature strings whose UTF-8 byte lengths are
+even and confirm both return `BadEncoding` without panicking. Feed accepted and
+rejected events containing sentinel device/zone ids, labels, hashes, signer
+material and signatures through the live viewer. Confirm its public frame and
+HTTP SSE contain none of the sentinels or sensitive field names while retaining
+the acceptance flag, stable rejection code, privacy disposition and aggregate
+counters.


### PR DESCRIPTION
## Summary

1. Adds explicit simulation, captured replay, and production trust modes.
2. Verifies Ed25519 signatures against an independently provisioned sensor key registry with revocation, freshness, binding, and replay checks.
3. Ensures rejected events cannot mutate replay state, the fusion graph, or inference windows.
4. Replaces raw live SSE payloads with a privacy guarded public projection and stable rejection codes.
5. Adds ADR 261 and reconciles ADR 260 without changing the external ADR 262 transport contract.

## Validation

1. Full Rust workspace: 130 passed, 0 failed.
2. Focused trust and viewer tests include malformed Unicode credentials, self signed keys, revocation, replay, privacy denial, and HTTP SSE redaction.
3. Rust formatting and diff checks passed.
4. Ruflo MetaHarness threat model reported info as the worst severity and no MCP surface.

## Residual risks

1. The reference viewer still needs an atomic integrity protected adapter for replay watermarks across process restarts.
2. Aggregate rejection diagnostics still require deployment endpoint access control.
3. This change establishes software trust policy. It does not validate hardware sensing accuracy.