### PR TITLE
security: authorize composite FieldEvent privacy

### DIFF
--- a/crates/rufield-privacy/src/lib.rs
+++ b/crates/rufield-privacy/src/lib.rs
@@ -8,12 +8,16 @@
 //! - **P4** (biometric / health) requires explicit consent,
 //! - **P5** (identity-linked) requires explicit identity binding + audit log.
 //!
-//! [`DefaultPrivacyGuard::authorize`] returns [`PrivacyDecision::Allow`],
-//! [`PrivacyDecision::Deny`], or [`PrivacyDecision::RequiresConsent`].
+//! [`DefaultPrivacyGuard::authorize`] authorizes one classified component.
+//! [`DefaultPrivacyGuard::authorize_event`] authorizes a complete [`FieldEvent`]
+//! by requiring every independently classified component to pass policy. Use
+//! the latter before serializing or transmitting a whole event.
 
 #![doc(html_root_url = "https://docs.rs/rufield-privacy/0.1.0")]
 
-use rufield_core::{Destination, PrivacyClass, PrivacyDecision, PrivacyGuard};
+use rufield_core::{
+    Destination, FieldEvent, PrivacyClass, PrivacyDecision, PrivacyGuard,
+};
 
 /// Tunable privacy policy. Defaults match ADR-260 §10.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +55,61 @@ impl DefaultPrivacyGuard {
     #[must_use]
     pub fn policy(&self) -> &PrivacyPolicy {
         &self.policy
+    }
+
+    /// Authorize a complete [`FieldEvent`] for a destination.
+    ///
+    /// A `FieldEvent` contains independently classified data. In v0.1 that
+    /// includes at least the numeric tensor and the derived observation. A
+    /// caller that authorizes only `event.observation.privacy_class` can
+    /// otherwise approve a P1/P2 observation while serializing a P0 raw tensor
+    /// in the same object.
+    ///
+    /// This method is deliberately conjunctive rather than reducing P0..P5 to
+    /// one scalar with `min` or `max`: the classes encode different policy
+    /// semantics. P0 has a special raw-waveform network prohibition, while P4
+    /// and P5 have consent and identity requirements. Every component must
+    /// therefore be authorized independently.
+    ///
+    /// Decision precedence is fail closed: any `Deny` dominates;
+    /// `RequiresConsent` dominates `Allow`. The returned reason identifies the
+    /// component that blocked the event.
+    #[must_use]
+    pub fn authorize_event(
+        &self,
+        event: &FieldEvent,
+        destination: Destination,
+        consent: bool,
+        identity_bound: bool,
+    ) -> PrivacyDecision {
+        let tensor = self.authorize(
+            event.tensor.privacy_class,
+            destination,
+            consent,
+            identity_bound,
+        );
+        let observation = self.authorize(
+            event.observation.privacy_class,
+            destination,
+            consent,
+            identity_bound,
+        );
+
+        match (tensor, observation) {
+            (PrivacyDecision::Deny(reason), _) => {
+                PrivacyDecision::Deny(format!("tensor: {reason}"))
+            }
+            (_, PrivacyDecision::Deny(reason)) => {
+                PrivacyDecision::Deny(format!("observation: {reason}"))
+            }
+            (PrivacyDecision::RequiresConsent(reason), _) => {
+                PrivacyDecision::RequiresConsent(format!("tensor: {reason}"))
+            }
+            (_, PrivacyDecision::RequiresConsent(reason)) => {
+                PrivacyDecision::RequiresConsent(format!("observation: {reason}"))
+            }
+            (PrivacyDecision::Allow, PrivacyDecision::Allow) => PrivacyDecision::Allow,
+        }
     }
 }
 
@@ -112,15 +171,57 @@ impl PrivacyGuard for DefaultPrivacyGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rufield_core::{
+        FieldAxis, FieldTensor, Modality, Observation, ProvenanceRef, SensorDescriptor,
+    };
 
     fn guard() -> DefaultPrivacyGuard {
         DefaultPrivacyGuard::default()
     }
 
+    fn event_with_classes(
+        tensor_class: PrivacyClass,
+        observation_class: PrivacyClass,
+    ) -> FieldEvent {
+        let tensor = FieldTensor::new(
+            1,
+            Modality::WifiCsi,
+            vec![FieldAxis::Frequency],
+            vec![1],
+            vec![0.5],
+            0.9,
+            0.01,
+            Some("cal-1".into()),
+            tensor_class,
+        )
+        .unwrap();
+        FieldEvent::new(
+            "event-1",
+            1,
+            SensorDescriptor {
+                modality: "wifi_csi".into(),
+                vendor: "test".into(),
+                device_id: "device-1".into(),
+                placement: "test".into(),
+                clock_domain: "test".into(),
+            },
+            tensor,
+            Observation::occupancy(0.9, observation_class),
+            ProvenanceRef {
+                raw_hash: "sha256:test".into(),
+                firmware_hash: "sha256:test".into(),
+                model_id: "test".into(),
+                calibration_id: "cal-1".into(),
+                synthetic: true,
+                signature_hex: None,
+                signer_pubkey_hex: None,
+            },
+        )
+    }
+
     #[test]
     fn p0_transmit_denied_by_default() {
         let d = guard().authorize(PrivacyClass::P0, Destination::Network, false, false);
-        matches!(d, PrivacyDecision::Deny(_));
         assert!(matches!(d, PrivacyDecision::Deny(_)));
     }
 
@@ -162,5 +263,70 @@ mod tests {
     fn p3_network_denied_above_ceiling() {
         let d = guard().authorize(PrivacyClass::P3, Destination::Network, false, false);
         assert!(matches!(d, PrivacyDecision::Deny(_)));
+    }
+
+    #[test]
+    fn event_denies_p0_tensor_even_when_p2_observation_is_allowed() {
+        let event = event_with_classes(PrivacyClass::P0, PrivacyClass::P2);
+        assert_eq!(
+            guard().authorize(PrivacyClass::P2, Destination::Network, false, false),
+            PrivacyDecision::Allow
+        );
+        let decision = guard().authorize_event(&event, Destination::Network, false, false);
+        match decision {
+            PrivacyDecision::Deny(reason) => {
+                assert!(reason.starts_with("tensor:"));
+                assert!(reason.contains("P0 raw waveform"));
+            }
+            other => panic!("expected composite event denial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_allows_p1_tensor_and_p2_observation() {
+        let event = event_with_classes(PrivacyClass::P1, PrivacyClass::P2);
+        assert_eq!(
+            guard().authorize_event(&event, Destination::Network, false, false),
+            PrivacyDecision::Allow
+        );
+    }
+
+    #[test]
+    fn event_propagates_observation_consent_requirement() {
+        let event = event_with_classes(PrivacyClass::P1, PrivacyClass::P4);
+        let required = guard().authorize_event(&event, Destination::Network, false, false);
+        match required {
+            PrivacyDecision::RequiresConsent(reason) => {
+                assert!(reason.starts_with("observation:"));
+            }
+            other => panic!("expected consent requirement, got {other:?}"),
+        }
+        assert_eq!(
+            guard().authorize_event(&event, Destination::Network, true, false),
+            PrivacyDecision::Allow
+        );
+    }
+
+    #[test]
+    fn event_propagates_observation_identity_requirement() {
+        let event = event_with_classes(PrivacyClass::P1, PrivacyClass::P5);
+        let denied = guard().authorize_event(&event, Destination::Network, true, false);
+        match denied {
+            PrivacyDecision::Deny(reason) => assert!(reason.starts_with("observation:")),
+            other => panic!("expected identity denial, got {other:?}"),
+        }
+        assert_eq!(
+            guard().authorize_event(&event, Destination::Network, true, true),
+            PrivacyDecision::Allow
+        );
+    }
+
+    #[test]
+    fn event_allows_p0_tensor_edge_local_when_observation_policy_allows() {
+        let event = event_with_classes(PrivacyClass::P0, PrivacyClass::P2);
+        assert_eq!(
+            guard().authorize_event(&event, Destination::EdgeLocal, false, false),
+            PrivacyDecision::Allow
+        );
     }
 }

--- a/docs/ADR-267-composite-event-privacy.md
+++ b/docs/ADR-267-composite-event-privacy.md
@@ -1,0 +1,181 @@
+# ADR-267: Composite FieldEvent Privacy Authorization
+
+Status: Proposed
+
+Date: 2026-08-24
+
+Issue: #6
+
+## Context
+
+RuField MFS v0.1 classifies both `FieldTensor` and `Observation` independently. The default privacy guard authorizes one `PrivacyClass` at a time. A complete `FieldEvent` can therefore contain components with different policy requirements.
+
+The reference simulator demonstrates the case directly: raw sensor tensors are P0 while derived occupancy and motion observations can be P1 or P2. A caller that checks only `event.observation.privacy_class` can obtain `Allow` for network export while serializing a P0 tensor in the same object.
+
+This is a library boundary problem even where a current integration is safe. RuView ADR-262 currently exports derived feature tensors stamped with the same egress class as their observations, so the live RuView `/api/field` and `/ws/field` bridge does not reproduce the P0 plus P2 mismatch. Other adapters, including captured CSI replay, can.
+
+External direction reinforces object-boundary authorization. ETSI GR ISC 007 covers security, privacy, resilience and trustworthiness for ISAC. ETSI GR ISC 008 explicitly covers sensing data acquisition, processing, fusion, compression, model lifecycle and secure, robust and accurate sensing results. Privacy-preserving ISAC research is also moving policy into measurement configuration rather than treating privacy as a presentation-only concern.
+
+Relevant sources:
+
+https://portal.etsi.org/webapp/workProgram/Report_WorkItem.asp?wki_id=77924
+
+https://portal.etsi.org/webapp/WorkProgram/Report_WorkItem.asp?SearchPage=TRUE&WKI_ID=77922
+
+https://arxiv.org/abs/2608.21064
+
+## Problem
+
+`PrivacyGuard::authorize(class, ...)` is necessary but insufficient to answer whether a complete `FieldEvent` may cross a trust boundary.
+
+A scalar reduction is also unsafe. P0 through P5 are ordered for existing API compatibility, but they do not form a simple monotonic sensitivity lattice. P0 has a special raw-waveform network prohibition. P4 requires consent. P5 requires identity binding and audit. Taking `min` or `max` can erase one of those independent restrictions.
+
+## Constraints
+
+1. Preserve the v0.1 wire format.
+2. Preserve source compatibility for existing `PrivacyGuard` implementations.
+3. Add no dependency.
+4. Keep the decision deterministic and fail closed.
+5. Do not infer consent or identity binding from event content.
+6. A valid signature proves integrity, not authorization.
+7. Do not change sensing accuracy claims or evidence levels.
+
+## Options considered
+
+### Option A: Use the observation class only
+
+Rejected. This is the current caller pattern that can ignore a more restrictive tensor.
+
+### Option B: Use `max(tensor_class, observation_class)`
+
+Rejected. P0 is raw and has a special prohibition while P4 and P5 use different authorization conditions. Numeric ordering cannot represent the conjunction.
+
+### Option C: Introduce a new multidimensional privacy lattice in the wire format
+
+Deferred. This is architecturally cleaner for a future MFS version, but it creates a wire migration and is unnecessary to close the current authorization gap.
+
+### Option D: Authorize every classified component and compose decisions
+
+Accepted. It is additive, explicit and preserves the current contract.
+
+## Decision
+
+Add `DefaultPrivacyGuard::authorize_event`.
+
+For each complete `FieldEvent`, authorize the tensor and observation independently under the same destination and caller supplied consent and identity context.
+
+Decision precedence is:
+
+1. Any `Deny` produces `Deny`.
+2. Otherwise any `RequiresConsent` produces `RequiresConsent`.
+3. Only two `Allow` decisions produce `Allow`.
+
+The returned reason identifies the component that blocked authorization.
+
+## Architecture
+
+```text
+FieldEvent
+  tensor privacy class       -> authorize component
+  observation privacy class  -> authorize component
+                               -> fail closed composition
+                               -> event decision
+```
+
+This is intentionally an object-boundary API. Component authorization remains available for projections that truly serialize only one component.
+
+## Interfaces
+
+```rust
+pub fn authorize_event(
+    &self,
+    event: &FieldEvent,
+    destination: Destination,
+    consent: bool,
+    identity_bound: bool,
+) -> PrivacyDecision;
+```
+
+## Data flow
+
+A network surface that serializes a whole `FieldEvent` must call `authorize_event` immediately before serialization. A surface that creates an explicitly derived projection may authorize the fields present in that projection, but must not use an observation decision as authorization for data it did not classify.
+
+## Security considerations
+
+The change closes a confused-deputy style authorization gap where the caller selects the least restrictive component class.
+
+It does not authenticate the caller, establish consent, verify retention policy, or prove that a claimed class is correctly assigned. Those remain separate controls.
+
+No unsafe Rust is introduced. No parsing or network input surface is added.
+
+## Privacy considerations
+
+The event is exportable only when every included classified component is exportable. This prevents P0 raw CSI or radar data from piggybacking on a P1 or P2 semantic observation authorization.
+
+Future MFS work should consider multidimensional privacy attributes rather than overloading one ordered enum for rawness, aggregation, biometric sensitivity and identity linkage.
+
+## Performance implications
+
+Two small enum policy evaluations replace one when authorizing a complete event. Expected added latency is below measurement noise and allocation cost is limited to denial or consent reason strings.
+
+## Hardware implications
+
+None.
+
+## Compatibility
+
+No wire change. No change to `PrivacyGuard`. Existing scalar callers continue to compile.
+
+Network surfaces that serialize complete events should migrate to `authorize_event`.
+
+## Migration
+
+1. Add the composite API.
+2. Add regression tests.
+3. Audit complete-event network surfaces.
+4. Migrate complete-event callers incrementally.
+5. Keep component-specific authorization only for explicitly projected payloads.
+
+## Alternatives rejected
+
+Scalar max classification, wire-version rewrite, and implicit authorization based on provenance were rejected because they either lose policy semantics, create unnecessary migration cost, or confuse integrity with authorization.
+
+## Risks
+
+The main residual risk is incorrect component classification. Composite authorization cannot detect a tensor falsely labeled P1 when it actually contains raw P0 data. Adapter conformance tests and provenance receipts remain necessary.
+
+## Open questions
+
+1. Should MFS v0.2 replace P0 through P5 with orthogonal dimensions such as rawness, identifiability, health sensitivity and aggregation?
+2. Should `FieldEvent` carry an explicit export projection so raw tensors can remain edge-local while observations cross the network without duplicating event types?
+3. Should authorization context become a typed capability rather than booleans for consent and identity binding?
+
+## Benchmark plan
+
+Security property baseline:
+
+Before: `authorize(P2, Network, false, false) == Allow` even when the same serialized event contains a P0 tensor.
+
+After: `authorize_event(P0 tensor + P2 observation, Network, false, false) == Deny` with a tensor-specific reason.
+
+Regression matrix:
+
+1. P1 tensor plus P2 observation: Allow.
+2. P0 tensor plus P2 observation: Deny on network.
+3. P1 tensor plus P4 observation without consent: RequiresConsent.
+4. The same P4 event with consent: Allow.
+5. P1 tensor plus P5 observation without identity binding: Deny.
+6. P0 tensor plus P2 observation at `EdgeLocal`: Allow subject to retention controls outside this API.
+
+## Acceptance criteria
+
+1. All composite policy tests pass.
+2. P0 plus P2 network transport is structurally denied.
+3. Existing scalar policy tests remain green.
+4. No dependency or wire-format change.
+5. Workspace clippy and tests pass.
+6. The PR documents that RuView's current live bridge uses same-class derived tensors and therefore does not claim a previously observed live leak.
+
+## Rollback strategy
+
+Revert the additive method, tests and ADR. No stored data or wire migration is affected.


### PR DESCRIPTION
## Problem

`PrivacyGuard::authorize` evaluates one `PrivacyClass`, but a complete `FieldEvent` contains independently classified tensor and observation payloads. Checking only the observation can approve P2 while the same serialized event contains a P0 raw tensor.

Closes #6.

## Research basis

This follows the direction of ETSI ISAC security, privacy, trustworthiness, and data-handling work, which treats sensing data exposure as a first-class governed boundary. Recent ISAC privacy research also reinforces that sensing privacy cannot be reduced to application presentation policy alone.

References:

* ETSI GR ISC 007, Security, Privacy, Resilience and Trustworthiness
* ETSI GR ISC 008, AIML and Data Handling for ISAC
* arXiv 2608.21064, Privacy-Preserving Localization via Transmit Antenna Selection and Permutation

## Architecture

Adds `DefaultPrivacyGuard::authorize_event` as an additive object-boundary API.

Each independently classified event component is authorized under the same destination and authorization context. Decisions compose fail closed:

1. Any `Deny` dominates.
2. Otherwise any `RequiresConsent` dominates.
3. Only all `Allow` decisions produce `Allow`.

The implementation deliberately does not use numeric `min` or `max`. P0 through P5 encode different policy semantics: P0 has a raw-waveform network prohibition, P4 requires consent, and P5 requires identity binding.

## Implementation summary

* Adds whole-event composite authorization to `rufield-privacy`.
* Preserves the existing scalar `PrivacyGuard` API.
* Adds regression coverage for P0 tensor plus P2 observation.
* Adds consent and identity composition tests.
* Adds ADR-267 documenting options, migration, threat model, acceptance criteria, and rollback.
* Adds no dependencies and changes no wire bytes.

## Files changed

* `crates/rufield-privacy/src/lib.rs`
* `docs/ADR-267-composite-event-privacy.md`

## Security review

Threat closed: confused-deputy style component selection where a caller authorizes the least restrictive part of a richer object.

The method does not infer consent, treat signatures as authorization, or weaken P0 handling. No unsafe Rust or network parser is added.

Residual risk: an adapter can still misclassify raw data as a lower class. Adapter conformance and provenance remain required.

## Compatibility

Source compatible and wire compatible. Complete-event network surfaces can migrate incrementally. Projections that serialize only derived fields may continue to authorize the data they actually include.

RuView note: the current live ADR-262 bridge stamps its derived feature tensor and observation with the same egress class, so this PR does not claim a known live RuView leak. The unsafe pattern exists at the general RuField object API and in adapters where raw P0 tensors coexist with lower-class observations.

## Before and after

Before:

`authorize(P2, Network, false, false) == Allow` can be used while serializing a `FieldEvent` that also contains a P0 tensor.

After:

`authorize_event(P0 tensor + P2 observation, Network, false, false) == Deny` and the reason identifies `tensor` as the blocking component.

## Tests

Added deterministic tests for:

* P0 tensor plus P2 observation network denial
* P1 tensor plus P2 observation network allow
* P4 consent propagation
* P5 identity-binding propagation
* P0 edge-local behavior
* all existing scalar policy cases

The execution environment for this research run could not resolve GitHub from the local container, so local Cargo validation was not available. GitHub CI is the authoritative validation gate for this PR and no merge should occur unless it is green.

## Known limitations

The P0..P5 enum still mixes rawness, aggregation, biometric sensitivity, and identity semantics. ADR-267 recommends evaluating orthogonal privacy dimensions for a future MFS wire revision.

## Rollback

Revert the additive method, tests, and ADR. No migration or stored-data rollback is required.
