### PR TITLE
feat(core): add deterministic evidence freshness assessment

### DIFF
--- a/crates/rufield-core/src/freshness.rs
+++ b/crates/rufield-core/src/freshness.rs
@@ -1,0 +1,194 @@
+//! Deterministic evidence freshness assessment for distributed sensing.
+//!
+//! A `FieldInference` already carries production and expiry timestamps, but
+//! those values do not say how old the supporting sensor evidence was when the
+//! result was evaluated. Distributed sensing also needs to distinguish stale
+//! evidence, a temporally incoherent cohort, and suspicious future timestamps.
+//!
+//! This module is deliberately pure. It reads no clock, mutates no trust state,
+//! allocates no intermediate collection, and changes no existing wire type.
+
+use serde::{Deserialize, Serialize};
+
+/// Task specific limits used to decide whether supporting evidence is usable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FreshnessPolicy {
+    /// Maximum permitted age of the oldest supporting evidence.
+    pub maximum_age_ns: u64,
+    /// Maximum permitted span from oldest to newest evidence in one cohort.
+    pub maximum_cohort_span_ns: u64,
+    /// Maximum permitted positive timestamp skew beyond evaluation time.
+    pub maximum_future_skew_ns: u64,
+}
+
+/// Deterministic reason assigned to an evidence cohort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FreshnessDisposition {
+    /// Every configured timing constraint is satisfied.
+    Fresh,
+    /// At least one timestamp is too far ahead of evaluation time.
+    FutureSkew,
+    /// The supporting observations span too wide a capture interval.
+    IncoherentCohort,
+    /// The oldest supporting observation exceeds the task age budget.
+    StaleEvidence,
+}
+
+/// Auditable timing assessment for one set of supporting evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FreshnessAssessment {
+    /// Number of supporting timestamps evaluated.
+    pub evidence_count: usize,
+    /// Oldest supporting capture timestamp.
+    pub oldest_evidence_ns: u64,
+    /// Newest supporting capture timestamp.
+    pub newest_evidence_ns: u64,
+    /// Caller supplied evaluation timestamp.
+    pub evaluated_at_ns: u64,
+    /// Age of the oldest supporting evidence at evaluation time.
+    pub oldest_age_ns: u64,
+    /// Age of the newest supporting evidence at evaluation time.
+    pub newest_age_ns: u64,
+    /// Capture span between the oldest and newest supporting evidence.
+    pub cohort_span_ns: u64,
+    /// Result of applying the supplied policy.
+    pub disposition: FreshnessDisposition,
+}
+
+impl FreshnessAssessment {
+    /// Whether the evidence cohort satisfies every configured timing limit.
+    #[must_use]
+    pub fn is_fresh(&self) -> bool {
+        self.disposition == FreshnessDisposition::Fresh
+    }
+}
+
+/// Assess source evidence timing without reading a clock or mutating state.
+///
+/// Returns `None` for an empty evidence set. The caller must not reinterpret
+/// absence as freshness.
+///
+/// Disposition precedence is fail closed and deterministic:
+///
+/// 1. future skew,
+/// 2. incoherent cohort span,
+/// 3. stale oldest evidence,
+/// 4. fresh.
+///
+/// Limits are inclusive. Evidence exactly on a configured boundary is accepted.
+#[must_use]
+pub fn assess_evidence_freshness(
+    evidence_times_ns: &[u64],
+    evaluated_at_ns: u64,
+    policy: FreshnessPolicy,
+) -> Option<FreshnessAssessment> {
+    let (&first, rest) = evidence_times_ns.split_first()?;
+    let mut oldest = first;
+    let mut newest = first;
+
+    for &timestamp_ns in rest {
+        oldest = oldest.min(timestamp_ns);
+        newest = newest.max(timestamp_ns);
+    }
+
+    let cohort_span_ns = newest.saturating_sub(oldest);
+    let oldest_age_ns = evaluated_at_ns.saturating_sub(oldest);
+    let newest_age_ns = evaluated_at_ns.saturating_sub(newest);
+    let future_skew_ns = newest.saturating_sub(evaluated_at_ns);
+
+    let disposition = if newest > evaluated_at_ns
+        && future_skew_ns > policy.maximum_future_skew_ns
+    {
+        FreshnessDisposition::FutureSkew
+    } else if cohort_span_ns > policy.maximum_cohort_span_ns {
+        FreshnessDisposition::IncoherentCohort
+    } else if oldest_age_ns > policy.maximum_age_ns {
+        FreshnessDisposition::StaleEvidence
+    } else {
+        FreshnessDisposition::Fresh
+    };
+
+    Some(FreshnessAssessment {
+        evidence_count: evidence_times_ns.len(),
+        oldest_evidence_ns: oldest,
+        newest_evidence_ns: newest,
+        evaluated_at_ns,
+        oldest_age_ns,
+        newest_age_ns,
+        cohort_span_ns,
+        disposition,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> FreshnessPolicy {
+        FreshnessPolicy {
+            maximum_age_ns: 100,
+            maximum_cohort_span_ns: 50,
+            maximum_future_skew_ns: 5,
+        }
+    }
+
+    #[test]
+    fn empty_evidence_has_no_assessment() {
+        assert!(assess_evidence_freshness(&[], 1_000, policy()).is_none());
+    }
+
+    #[test]
+    fn exact_policy_boundaries_are_fresh() {
+        let assessment = assess_evidence_freshness(&[900, 950], 1_000, policy()).unwrap();
+        assert_eq!(assessment.oldest_age_ns, 100);
+        assert_eq!(assessment.cohort_span_ns, 50);
+        assert_eq!(assessment.disposition, FreshnessDisposition::Fresh);
+        assert!(assessment.is_fresh());
+    }
+
+    #[test]
+    fn stale_oldest_evidence_is_withheld() {
+        let assessment = assess_evidence_freshness(&[899, 949], 1_000, policy()).unwrap();
+        assert_eq!(assessment.disposition, FreshnessDisposition::StaleEvidence);
+        assert!(!assessment.is_fresh());
+    }
+
+    #[test]
+    fn incoherent_cohort_precedes_staleness() {
+        let assessment = assess_evidence_freshness(&[800, 1_000], 1_000, policy()).unwrap();
+        assert_eq!(
+            assessment.disposition,
+            FreshnessDisposition::IncoherentCohort
+        );
+    }
+
+    #[test]
+    fn future_skew_is_fail_closed_and_has_highest_precedence() {
+        let assessment = assess_evidence_freshness(&[800, 1_006], 1_000, policy()).unwrap();
+        assert_eq!(assessment.disposition, FreshnessDisposition::FutureSkew);
+        assert_eq!(assessment.newest_age_ns, 0);
+    }
+
+    #[test]
+    fn permitted_clock_skew_does_not_manufacture_age() {
+        let assessment = assess_evidence_freshness(&[955, 1_005], 1_000, policy()).unwrap();
+        assert_eq!(assessment.disposition, FreshnessDisposition::Fresh);
+        assert_eq!(assessment.newest_age_ns, 0);
+    }
+
+    #[test]
+    fn input_order_does_not_change_assessment() {
+        let a = assess_evidence_freshness(&[970, 940, 960], 1_000, policy()).unwrap();
+        let b = assess_evidence_freshness(&[960, 970, 940], 1_000, policy()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn assessment_round_trips_as_json() {
+        let assessment = assess_evidence_freshness(&[970, 940], 1_000, policy()).unwrap();
+        let json = serde_json::to_string(&assessment).unwrap();
+        let back: FreshnessAssessment = serde_json::from_str(&json).unwrap();
+        assert_eq!(assessment, back);
+    }
+}

--- a/crates/rufield-core/src/lib.rs
+++ b/crates/rufield-core/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod error;
 pub mod event;
+pub mod freshness;
 pub mod inference;
 pub mod modality;
 pub mod privacy;
@@ -28,6 +29,9 @@ pub use event::{
     IdentityEvidenceKind, Observation, ProvenanceRef, PseudonymousId, SensorDescriptor,
     MAX_CHANNEL_SOUNDING_CHANNELS, MAX_CHANNEL_SOUNDING_CHANNEL_INDEX,
     MAX_IDENTITY_EVIDENCE_TTL_NS, MIN_CHANNEL_SOUNDING_CHANNELS, MIN_IDENTITY_EVIDENCE_CONFIDENCE,
+};
+pub use freshness::{
+    assess_evidence_freshness, FreshnessAssessment, FreshnessDisposition, FreshnessPolicy,
 };
 pub use inference::{
     AbstentionReason, CalibratedInference, CalibrationContext, FieldEmbedding, FieldInference,

--- a/docs/ADR-271-evidence-freshness.md
+++ b/docs/ADR-271-evidence-freshness.md
@@ -1,0 +1,249 @@
+# ADR 271: Evidence Freshness and Cohort Timing
+
+Status: Proposed
+
+Date: 2026-08-31
+
+Issue: #12
+
+## Context
+
+RuField already models capture timestamps, inference production and expiry, calibrated uncertainty, provenance, privacy, and abstention. Those fields do not answer a different question: how old was the supporting sensor evidence when a result was evaluated, and did the contributing observations belong to one temporally coherent sensing cohort?
+
+This distinction matters in distributed RF sensing, semantic communication, tracking, and active sensing. A valid model output can still be operationally unsafe when its source observations are stale or temporally inconsistent.
+
+SafeStep, arXiv 2608.27688, demonstrates a live semantic communication system where Age of Information is an explicit control variable and where downstream task degradation becomes observable as evidence age changes. This is not direct evidence for a universal RuField threshold. It is evidence that evidence age belongs in the contract rather than remaining an implicit application assumption.
+
+RuView issue 1726 independently exposed the same systems concern from multistatic sensing. Slow but live nodes can contribute frames outside the fuser coherence guard. RuView now selects a coherent cohort before governed fusion. RuField needs a modality neutral representation for downstream consumers to assess the timing quality of supporting evidence.
+
+The authenticated BLE and Channel Sounding path also exposed an adversarial timestamp hazard. A hostile far future timestamp must be rejected before it can influence shared freshness or replay state.
+
+## Problem
+
+`FieldInference::expires_ns` defines how long a produced inference remains valid. It does not encode source evidence age, evidence span, or future clock skew.
+
+Using only the inference expiry can therefore hide three distinct failure modes:
+
+1. Old evidence may be wrapped in a newly produced inference.
+2. Individually recent observations may span too wide a capture interval to be fused coherently.
+3. A future timestamp may appear fresh under saturating age arithmetic unless future skew is checked explicitly.
+
+## Constraints
+
+1. Existing `FieldEvent` and `FieldInference` wire forms must not change.
+2. Existing public struct literals must remain source compatible.
+3. The core assessment must be deterministic and replayable.
+4. The core must not read the wall clock.
+5. The core must not mutate trust, replay, or watermark state.
+6. Timing thresholds are task specific and must not be globally hard coded.
+7. Empty evidence must never be interpreted as fresh evidence.
+8. Arithmetic must remain defined at `u64` boundaries.
+
+## Options considered
+
+### Option 1: Reuse inference expiry
+
+Rejected. Production lifetime and source evidence age are different quantities.
+
+### Option 2: Add freshness fields directly to `FieldInference`
+
+Rejected for this release. Adding required public fields would break external Rust struct literals and would change the serialized shape of the established inference type.
+
+### Option 3: Add an additive assessment primitive
+
+Chosen. A pure helper computes an explicit `FreshnessAssessment` from supporting evidence timestamps, caller supplied evaluation time, and task supplied policy.
+
+### Option 4: Put one global age threshold in RuField
+
+Rejected. Presence, collision avoidance, occupancy analytics, semantic communication, and archival analysis have materially different age budgets.
+
+## Prior art
+
+1. SafeStep, arXiv 2608.27688, treats Age of Information as a first class semantic communication variable and reports downstream task degradation across communication conditions.
+2. IEEE 802.11bf defines WLAN sensing procedures where measurement timing is part of the sensing process, but it does not supply one application level freshness threshold for RuField consumers.
+3. ETSI GR ISC 003 separates sensing task coordination, measurement configuration, processing, storage, and result exposure, which supports task scoped timing policy rather than a global limit.
+4. 3GPP Release 20 ISAC work separates sensing functions, sensing tasks, measurements, results, and exposure. Draft details remain subject to change, so RuField keeps the primitive modality and standards neutral.
+5. RuView issue 1726 enforces a hard multistatic capture guard before fusion, demonstrating the need to distinguish node liveness from cohort coherence.
+
+## Decision
+
+Add the following additive public API to `rufield-core`:
+
+`FreshnessPolicy`
+
+`FreshnessDisposition`
+
+`FreshnessAssessment`
+
+`assess_evidence_freshness`
+
+The helper performs one pass over a timestamp slice and returns no assessment for empty input.
+
+Disposition precedence is deterministic and fail closed:
+
+1. `FutureSkew`
+2. `IncoherentCohort`
+3. `StaleEvidence`
+4. `Fresh`
+
+Limits are inclusive. A value exactly on a configured boundary remains acceptable.
+
+## Architecture
+
+Input:
+
+Supporting evidence capture timestamps
+
+Caller supplied evaluation timestamp
+
+Task supplied freshness policy
+
+Output:
+
+Oldest and newest source timestamps
+
+Oldest and newest evidence age
+
+Cohort capture span
+
+Evidence count
+
+Deterministic disposition
+
+No model confidence is modified by this helper. No privacy decision is modified by this helper.
+
+## Interfaces
+
+```rust
+let policy = FreshnessPolicy {
+    maximum_age_ns: 100_000_000,
+    maximum_cohort_span_ns: 60_000_000,
+    maximum_future_skew_ns: 5_000_000,
+};
+
+let assessment = assess_evidence_freshness(
+    &[1_000_000_000, 1_020_000_000],
+    1_050_000_000,
+    policy,
+).expect("supporting evidence");
+
+if !assessment.is_fresh() {
+    // Caller chooses abstention, resensing, or a lower capability tier.
+}
+```
+
+## Data flow
+
+Sensor evidence enters through an existing adapter.
+
+Trusted evidence timestamps remain attached to events.
+
+A fusion or application layer selects supporting evidence.
+
+The application supplies its evaluation time and freshness policy.
+
+The core helper produces an auditable timing assessment.
+
+The caller decides whether to abstain, request new sensing, or continue.
+
+## Security considerations
+
+1. Future timestamp skew is checked before evidence can be classified fresh.
+2. The helper is pure and cannot advance a watermark or mutate replay state.
+3. Saturating arithmetic prevents integer underflow and overflow from becoming freshness bypasses.
+4. Empty evidence returns `None` rather than a default `Fresh` value.
+5. Caller supplied timestamps must still originate from the existing trust and provenance pipeline. Freshness assessment does not authenticate evidence.
+6. A malicious caller can choose an unsafe policy. Policy authorization belongs in the sensing task or capability layer and is not weakened here.
+
+## Privacy considerations
+
+The assessment exposes timing metadata and aggregate timing properties. It does not authorize transmission, lower a privacy class, reveal raw waveform data, or establish identity.
+
+Applications should still consider timing information sensitive where it can reveal presence patterns or operational schedules.
+
+## Performance implications
+
+The implementation performs one pass over supporting timestamps and creates no intermediate collection. Time complexity is O(n) in supporting evidence count. Additional memory is O(1).
+
+No wall clock performance claim is made until a reproducible benchmark is added.
+
+## Hardware implications
+
+None in the core crate.
+
+Hardware integrations should provide trustworthy capture timestamps and clock quality. The assessment cannot repair an unknown clock domain or missing synchronization.
+
+## Compatibility
+
+Existing wire structures are unchanged.
+
+Existing `FieldEvent`, `FieldInference`, `CalibratedInference`, and `UncertaintyEnvelope` JSON remain unchanged.
+
+The new types are additive exports.
+
+## Migration
+
+No migration is required.
+
+Consumers opt in when they have supporting evidence timestamps and a task specific timing policy.
+
+## Alternatives rejected
+
+A single global freshness limit is rejected because it confuses application semantics.
+
+Automatic confidence decay is rejected because calibrated probability and data age are not interchangeable.
+
+Treating future timestamps as age zero without an explicit skew classification is rejected because it creates a security bypass.
+
+## Risks
+
+1. Consumers may choose thresholds without field evidence.
+2. Clock domains may be incomparable even when numeric timestamps appear close.
+3. A fresh evidence cohort may still be wrong, poisoned, or out of distribution.
+4. Applications may incorrectly treat `Fresh` as a full trust decision.
+
+## Open questions
+
+1. Should a future RuField sensing task schema carry mandatory freshness policy?
+2. Should `UncertaintyEnvelope` eventually reference a separate freshness receipt without changing the legacy inference wire type?
+3. Which thresholds are justified for presence, localization, tracking, vital signs, and semantic communication on real hardware?
+4. Should clock quality and synchronization uncertainty be composed into the policy rather than represented separately?
+
+## Benchmark plan
+
+Phase 1 validates deterministic classification and boundary behavior.
+
+Phase 2 benchmarks the helper on representative evidence counts and records hardware, compiler, run count, mean, p95, and variance.
+
+Phase 3 replays real RuView multistatic traces with controlled packet delay and loss to measure how freshness gating affects false continuity, localization error, and sensing availability.
+
+No synthetic result may be presented as field accuracy.
+
+## Acceptance criteria
+
+1. Exact policy boundaries remain fresh.
+2. Empty evidence produces no assessment.
+3. Excess future skew produces `FutureSkew`.
+4. Excess capture span produces `IncoherentCohort`.
+5. Excess oldest evidence age produces `StaleEvidence`.
+6. Input ordering does not affect the result.
+7. JSON round trip is deterministic.
+8. Existing core wire tests remain unchanged.
+9. Workspace tests pass.
+10. Strict clippy passes.
+
+## Rollback strategy
+
+Delete `freshness.rs` and remove its module and reexports from `rufield-core::lib`.
+
+No wire rollback, data migration, or persistent state repair is required.
+
+## Relevant research and standards
+
+SafeStep: https://arxiv.org/abs/2608.27688
+
+IEEE 802.11bf working group material: https://www.ieee802.org/11/Reports/tgbf_update.htm
+
+ETSI ISAC: https://www.etsi.org/technical-groups/isac/
+
+3GPP TR 38.765: https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=4357


### PR DESCRIPTION
## Problem

RuField can say when an inference was produced and when it expires, but it cannot currently say how old the supporting sensor evidence was or whether a distributed evidence cohort spans too wide a capture interval.

This matters for multistatic sensing, semantic communication, tracking, and active sensing. A newly produced inference can still be based on stale or temporally incoherent evidence.

Closes #12.

## Research basis

SafeStep, arXiv 2608.27688, makes Age of Information an explicit live semantic communication control variable and shows downstream task degradation as evidence age changes.

RuView issue 1726 recently fixed a related production failure by selecting only temporally coherent multistatic frame cohorts before governed fusion.

The RuField BLE trust path also demonstrated why future timestamps must be handled before shared timing state is advanced.

## Architecture

Adds a pure additive API in `rufield-core`:

`FreshnessPolicy`

`FreshnessDisposition`

`FreshnessAssessment`

`assess_evidence_freshness`

The helper takes supporting evidence timestamps, caller supplied evaluation time, and a task supplied policy. It performs one pass with O(n) time and O(1) additional memory.

Disposition precedence is fail closed:

1. `FutureSkew`
2. `IncoherentCohort`
3. `StaleEvidence`
4. `Fresh`

No existing wire struct gains a field.

## Files changed

`crates/rufield-core/src/freshness.rs`

`crates/rufield-core/src/lib.rs`

`docs/ADR-271-evidence-freshness.md`

## Security review

1. Future timestamps beyond policy cannot be interpreted as age zero freshness.
2. Saturating arithmetic avoids timestamp underflow and overflow hazards.
3. Empty evidence returns no assessment.
4. The helper reads no clock and mutates no watermark or replay state.
5. Freshness is not evidence authentication. Existing provenance and trust checks remain mandatory.
6. Freshness does not authorize export or lower privacy class.

## Compatibility

No existing `FieldEvent`, `FieldInference`, calibrated uncertainty, or tensor wire form changes.

The API is additive. No migration is required.

## Tests

The new module includes deterministic tests for:

1. Empty evidence.
2. Exact policy boundaries.
3. Stale evidence.
4. Cohort incoherence.
5. Future skew with precedence over other failures.
6. Permitted clock skew.
7. Input order invariance.
8. JSON round trip.

CI is expected to run the existing workspace suite and clippy gates. Results will be recorded after the GitHub checks complete.

## Benchmarks

No latency or sensing accuracy improvement is claimed in this PR. The implementation is single pass and allocation free by inspection, but wall clock benchmark numbers are intentionally deferred until they can be recorded with hardware, compiler, run count, and variance.

The measurable improvement in this PR is a new deterministic classification gate: current main has no machine readable way to distinguish stale evidence, incoherent cohorts, and excessive future skew. The branch does.

## Known limitations

1. The core does not choose application thresholds.
2. It does not establish whether clock domains are comparable.
3. It does not automatically abstain or resense.
4. It does not modify model confidence.

Those choices belong in sensing task and application policy layers after measured thresholds exist.

## Rollback

Delete the new module and remove its module and reexports. There is no data migration or persistent state repair.

## ADR

ADR 271 documents context, prior art, interfaces, security, privacy, compatibility, benchmark plan, acceptance criteria, and rollback.