### PR TITLE
feat(interop): add bounded ISAC standards references

### DIFF
--- a/crates/rufield-interop/src/lib.rs
+++ b/crates/rufield-interop/src/lib.rs
@@ -5,6 +5,11 @@
 //! an already normalized [`rufield_core::FieldEvent`] to CloudEvents 1.0 and a
 //! compact SOSA observation envelope while preserving the native event as the
 //! lossless payload.
+//!
+//! Moving standards drafts such as 3GPP Release 20 ISAC and ETSI ISAC work are
+//! represented separately as bounded [`StandardsReference`] metadata. A
+//! reference records which document informed an integration; it is never a
+//! protocol implementation, certification, or compliance claim.
 
 use rufield_core::{FieldEvent, Modality};
 use serde::{Deserialize, Serialize};
@@ -16,6 +21,14 @@ pub const CLOUD_EVENTS_SPEC_VERSION: &str = "1.0";
 pub const SOSA_NAMESPACE: &str = "http://www.w3.org/ns/sosa/";
 /// RuField namespace used by the JSON LD projection.
 pub const RUFIELD_NAMESPACE: &str = "https://github.com/ruvnet/rufield/spec/";
+/// Maximum standards references attached to one interop envelope.
+pub const MAX_STANDARDS_REFERENCES: usize = 16;
+/// Maximum bytes accepted in a standards document identifier.
+pub const MAX_STANDARD_DOCUMENT_ID_BYTES: usize = 96;
+/// Maximum bytes accepted in a standards version.
+pub const MAX_STANDARD_VERSION_BYTES: usize = 32;
+/// Maximum bytes accepted in an optional release or stage descriptor.
+pub const MAX_STANDARD_STAGE_BYTES: usize = 48;
 
 /// The acquisition profile represented by an already normalized event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,6 +54,113 @@ impl SourceProfile {
     }
 }
 
+/// Standards organization associated with a non-normative reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StandardsOrganization {
+    /// Third Generation Partnership Project.
+    ThreeGpp,
+    /// European Telecommunications Standards Institute.
+    Etsi,
+    /// Institute of Electrical and Electronics Engineers.
+    Ieee,
+    /// Bluetooth Special Interest Group.
+    BluetoothSig,
+    /// Wi-Fi Alliance.
+    WifiAlliance,
+    /// O-RAN Alliance.
+    ORan,
+    /// Internet Engineering Task Force.
+    Ietf,
+}
+
+/// Architectural role played by a standards reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StandardsRole {
+    /// Measurement or radio acquisition profile.
+    Acquisition,
+    /// Sensing service or network function interface.
+    SensingService,
+    /// Exposure of sensing results to vertical applications.
+    VerticalExposure,
+    /// Evaluation, demonstrability, or technology adoption profile.
+    EvaluationProfile,
+    /// Security, privacy, resilience, or trust guidance.
+    SecurityPrivacy,
+    /// Compute placement or edge inference guidance.
+    ComputePlacement,
+}
+
+/// Bounded, explicitly non-compliance metadata linking an interop envelope to a
+/// standards document that informed its shape or semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StandardsReference {
+    /// Standards body that owns the referenced document.
+    pub organization: StandardsOrganization,
+    /// Document identifier, for example `TS 23.138` or `GR ISC 009`.
+    pub document_id: String,
+    /// Exact version being referenced, for example `0.2.0`.
+    pub version: String,
+    /// Optional release or stage, for example `Release 20` or `Early draft`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release_or_stage: Option<String>,
+    /// Reference date in `YYYY-MM-DD` form.
+    pub reference_date: String,
+    /// How this document relates to the RuField envelope.
+    pub role: StandardsRole,
+    /// Must remain false. RuField metadata cannot manufacture a compliance claim.
+    #[serde(default)]
+    pub compliance_claim: bool,
+}
+
+impl StandardsReference {
+    /// Construct and validate an explicitly non-compliance standards reference.
+    pub fn new(
+        organization: StandardsOrganization,
+        document_id: impl Into<String>,
+        version: impl Into<String>,
+        release_or_stage: Option<String>,
+        reference_date: impl Into<String>,
+        role: StandardsRole,
+    ) -> Result<Self, InteropError> {
+        let reference = Self {
+            organization,
+            document_id: document_id.into(),
+            version: version.into(),
+            release_or_stage,
+            reference_date: reference_date.into(),
+            role,
+            compliance_claim: false,
+        };
+        reference.validate()?;
+        Ok(reference)
+    }
+
+    /// Validate bounds, text hygiene, date shape, and the non-compliance invariant.
+    pub fn validate(&self) -> Result<(), InteropError> {
+        if self.compliance_claim {
+            return Err(InteropError::new(
+                "standards reference cannot assert compliance",
+            ));
+        }
+        validate_text(
+            "standards document identifier",
+            &self.document_id,
+            MAX_STANDARD_DOCUMENT_ID_BYTES,
+        )?;
+        validate_text(
+            "standards version",
+            &self.version,
+            MAX_STANDARD_VERSION_BYTES,
+        )?;
+        if let Some(stage) = &self.release_or_stage {
+            validate_text("standards release or stage", stage, MAX_STANDARD_STAGE_BYTES)?;
+        }
+        validate_reference_date(&self.reference_date)
+    }
+}
+
 /// Lossless CloudEvents 1.0 structured event.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudEvent {
@@ -59,6 +179,9 @@ pub struct CloudEvent {
     pub datacontenttype: String,
     /// Source standard profile extension.
     pub sourceprofile: String,
+    /// Optional non-compliance references to evolving standards documents.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub standardsreferences: Vec<StandardsReference>,
     /// Integer capture time extension preserving nanosecond precision.
     pub timeunixnano: u64,
     /// Lossless native event.
@@ -106,6 +229,13 @@ pub struct SosaObservation {
     /// Source standard profile identifier.
     #[serde(rename = "rufield:sourceProfile")]
     pub source_profile: String,
+    /// Optional non-compliance references to evolving standards documents.
+    #[serde(
+        rename = "rufield:standardsReferences",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub standards_references: Vec<StandardsReference>,
     /// Lossless native event payload.
     #[serde(rename = "rufield:event")]
     pub event: FieldEvent,
@@ -140,9 +270,23 @@ pub fn to_cloud_event(event: &FieldEvent, profile: SourceProfile) -> CloudEvent 
         subject: event.sensor.device_id.clone(),
         datacontenttype: "application/vnd.rufield.event+json".into(),
         sourceprofile: profile.identifier().into(),
+        standardsreferences: Vec::new(),
         timeunixnano: event.timestamp_ns,
         data: event.clone(),
     }
+}
+
+/// Project a native event into CloudEvents and attach validated standards
+/// references that cannot assert certification or compliance.
+pub fn to_cloud_event_with_references(
+    event: &FieldEvent,
+    profile: SourceProfile,
+    standards_references: Vec<StandardsReference>,
+) -> Result<CloudEvent, InteropError> {
+    validate_standards_references(&standards_references)?;
+    let mut envelope = to_cloud_event(event, profile);
+    envelope.standardsreferences = standards_references;
+    Ok(envelope)
 }
 
 /// Validate and recover the lossless native event from CloudEvents.
@@ -153,6 +297,7 @@ pub fn from_cloud_event(envelope: CloudEvent) -> Result<FieldEvent, InteropError
     if envelope.event_type != "net.ruv.rufield.observation.v1" {
         return Err(InteropError::new("unsupported CloudEvents event type"));
     }
+    validate_standards_references(&envelope.standardsreferences)?;
     let expected_source = format!("urn:rufield:device:{}", envelope.data.sensor.device_id);
     if envelope.id != envelope.data.event_id
         || envelope.subject != envelope.data.sensor.device_id
@@ -194,8 +339,22 @@ pub fn to_sosa_observation(event: &FieldEvent, profile: SourceProfile) -> SosaOb
         },
         result_time_unix_nano: event.timestamp_ns,
         source_profile: profile.identifier().into(),
+        standards_references: Vec::new(),
         event: event.clone(),
     }
+}
+
+/// Project a native event into SOSA JSON LD and attach validated standards
+/// references that cannot assert certification or compliance.
+pub fn to_sosa_observation_with_references(
+    event: &FieldEvent,
+    profile: SourceProfile,
+    standards_references: Vec<StandardsReference>,
+) -> Result<SosaObservation, InteropError> {
+    validate_standards_references(&standards_references)?;
+    let mut envelope = to_sosa_observation(event, profile);
+    envelope.standards_references = standards_references;
+    Ok(envelope)
 }
 
 /// Validate and recover the lossless native event from SOSA JSON LD.
@@ -206,6 +365,7 @@ pub fn from_sosa_observation(envelope: SosaObservation) -> Result<FieldEvent, In
     {
         return Err(InteropError::new("unsupported SOSA context or type"));
     }
+    validate_standards_references(&envelope.standards_references)?;
     let expected_id = format!("urn:rufield:observation:{}", envelope.event.event_id);
     let expected_sensor = format!("urn:rufield:sensor:{}", envelope.event.sensor.device_id);
     let expected_property = format!(
@@ -233,6 +393,53 @@ pub fn from_sosa_observation(envelope: SosaObservation) -> Result<FieldEvent, In
 /// Serialize with stable struct field ordering for fixtures and signatures.
 pub fn deterministic_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(value)
+}
+
+fn validate_standards_references(references: &[StandardsReference]) -> Result<(), InteropError> {
+    if references.len() > MAX_STANDARDS_REFERENCES {
+        return Err(InteropError::new(format!(
+            "too many standards references: {} > {MAX_STANDARDS_REFERENCES}",
+            references.len()
+        )));
+    }
+    for reference in references {
+        reference.validate()?;
+    }
+    Ok(())
+}
+
+fn validate_text(field: &str, value: &str, maximum_bytes: usize) -> Result<(), InteropError> {
+    if value.is_empty() || value.len() > maximum_bytes || value.trim() != value {
+        return Err(InteropError::new(format!("invalid {field}")));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(InteropError::new(format!("invalid {field}")));
+    }
+    Ok(())
+}
+
+fn validate_reference_date(value: &str) -> Result<(), InteropError> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 10
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes
+            .iter()
+            .enumerate()
+            .any(|(index, byte)| index != 4 && index != 7 && !byte.is_ascii_digit())
+    {
+        return Err(InteropError::new("invalid standards reference date"));
+    }
+    let month = value[5..7]
+        .parse::<u8>()
+        .map_err(|_| InteropError::new("invalid standards reference date"))?;
+    let day = value[8..10]
+        .parse::<u8>()
+        .map_err(|_| InteropError::new("invalid standards reference date"))?;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return Err(InteropError::new("invalid standards reference date"));
+    }
+    Ok(())
 }
 
 fn modality_name(modality: Modality) -> &'static str {
@@ -275,6 +482,38 @@ mod tests {
         serde_json::from_str(include_str!("../../../fixtures/interop/field-event.json")).unwrap()
     }
 
+    fn isac_references() -> Vec<StandardsReference> {
+        vec![
+            StandardsReference::new(
+                StandardsOrganization::ThreeGpp,
+                "TS 23.138",
+                "0.2.0",
+                Some("Release 20 draft".into()),
+                "2026-09-02",
+                StandardsRole::VerticalExposure,
+            )
+            .unwrap(),
+            StandardsReference::new(
+                StandardsOrganization::ThreeGpp,
+                "TS 29.545",
+                "0.2.0",
+                Some("Release 20 draft".into()),
+                "2026-09-04",
+                StandardsRole::SensingService,
+            )
+            .unwrap(),
+            StandardsReference::new(
+                StandardsOrganization::Etsi,
+                "GR ISC 009",
+                "0.0.3",
+                Some("Early draft".into()),
+                "2026-09-02",
+                StandardsRole::EvaluationProfile,
+            )
+            .unwrap(),
+        ]
+    }
+
     #[test]
     fn cloud_event_matches_golden_and_round_trips() {
         let event = fixture_event();
@@ -295,6 +534,100 @@ mod tests {
         assert!(value["sosa:madeBySensor"]["@id"].is_string());
         assert!(value["sosa:observedProperty"]["@id"].is_string());
         assert_eq!(from_sosa_observation(envelope).unwrap(), event);
+    }
+
+    #[test]
+    fn evolving_standards_references_are_additive_and_round_trip() {
+        let event = fixture_event();
+        let references = isac_references();
+        let envelope = to_cloud_event_with_references(
+            &event,
+            SourceProfile::Ieee80211bf2025,
+            references.clone(),
+        )
+        .unwrap();
+        assert_eq!(envelope.standardsreferences, references);
+        let json = deterministic_json(&envelope).unwrap();
+        assert!(json.contains("TS 23.138"));
+        assert!(json.contains("GR ISC 009"));
+        assert_eq!(from_cloud_event(envelope).unwrap(), event);
+
+        let sosa = to_sosa_observation_with_references(
+            &event,
+            SourceProfile::Ieee80211bf2025,
+            isac_references(),
+        )
+        .unwrap();
+        let json = deterministic_json(&sosa).unwrap();
+        assert!(json.contains("rufield:standardsReferences"));
+        assert_eq!(from_sosa_observation(sosa).unwrap(), event);
+    }
+
+    #[test]
+    fn standards_metadata_cannot_manufacture_compliance() {
+        let event = fixture_event();
+        let mut reference = isac_references().remove(0);
+        reference.compliance_claim = true;
+        let err = to_cloud_event_with_references(
+            &event,
+            SourceProfile::RufieldNativeV01,
+            vec![reference],
+        )
+        .unwrap_err();
+        assert_eq!(err.to_string(), "standards reference cannot assert compliance");
+    }
+
+    #[test]
+    fn external_standards_metadata_is_bounded_and_sanitized() {
+        let event = fixture_event();
+        let oversized = "x".repeat(MAX_STANDARD_DOCUMENT_ID_BYTES + 1);
+        let reference = StandardsReference {
+            organization: StandardsOrganization::Etsi,
+            document_id: oversized,
+            version: "0.0.3".into(),
+            release_or_stage: None,
+            reference_date: "2026-09-02".into(),
+            role: StandardsRole::EvaluationProfile,
+            compliance_claim: false,
+        };
+        assert!(to_cloud_event_with_references(
+            &event,
+            SourceProfile::RufieldNativeV01,
+            vec![reference]
+        )
+        .is_err());
+
+        assert!(StandardsReference::new(
+            StandardsOrganization::ThreeGpp,
+            "TS 29.545\nforged",
+            "0.2.0",
+            None,
+            "2026-09-04",
+            StandardsRole::SensingService,
+        )
+        .is_err());
+        assert!(StandardsReference::new(
+            StandardsOrganization::ThreeGpp,
+            "TS 29.545",
+            "0.2.0",
+            None,
+            "2026-13-04",
+            StandardsRole::SensingService,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn too_many_standards_references_are_rejected() {
+        let event = fixture_event();
+        let reference = isac_references().remove(0);
+        let references = vec![reference; MAX_STANDARDS_REFERENCES + 1];
+        assert!(to_cloud_event_with_references(
+            &event,
+            SourceProfile::RufieldNativeV01,
+            references
+        )
+        .is_err());
     }
 
     #[test]

--- a/docs/ADR-271-isac-standards-references.md
+++ b/docs/ADR-271-isac-standards-references.md
@@ -1,0 +1,213 @@
+# ADR 271: Bounded ISAC standards references in interoperability envelopes
+
+Status: Proposed
+
+Date: 2026-09-07
+
+Issue: #14
+
+## Context
+
+RuField normalizes sensing evidence before projecting it into external interoperability envelopes. ADR 268 added deterministic CloudEvents 1.0 and SOSA JSON LD projections and intentionally treats IEEE 802.11bf and Bluetooth Channel Sounding as source identifiers rather than protocol or certification claims.
+
+The service and application layers around integrated sensing and communications are moving independently of radio acquisition formats. During the week ending 2026-09-07, 3GPP TS 23.138, Use of sensing results for Vertical Applications, advanced to draft 0.2.0 on 2026-09-02; 3GPP TS 29.545, Sensing Function Services Stage 3, advanced to draft 0.2.0 on 2026-09-04; and ETSI GR ISC 009, Demonstrability, Adoption, and Technology Evolution for ISAC, advanced to early draft 0.0.3 on 2026-09-02.
+
+These documents may inform a RuField integration even when the underlying measurement comes from native WiFi CSI, IEEE 802.11bf, Bluetooth Channel Sounding, UWB, radar, ultrasonic, or another modality.
+
+## Problem
+
+Encoding every moving draft as a `SourceProfile` would collapse two independent facts:
+
+1. how the measurement was acquired
+2. which external service, exposure, evaluation, security, or compute document informed an integration
+
+It would also make it too easy for a string such as `3gpp.ts.29.545` to be mistaken for a compliance claim.
+
+RuField needs a way to cite evolving standards without changing native `FieldEvent` semantics, breaking current golden fixtures, or implying that RuField implements or is certified against the referenced document.
+
+## Constraints
+
+* Native `FieldEvent` provenance remains authoritative and unchanged.
+* Existing `SourceProfile` identifiers remain byte stable.
+* Existing CloudEvents and SOSA golden fixtures remain byte identical when no standards references are attached.
+* External metadata is untrusted and bounded before it is accepted.
+* No input can manufacture a compliance or certification state.
+* Serialization remains deterministic for the same typed value.
+* The change introduces no new dependency.
+
+## Options considered
+
+### Extend `SourceProfile` for each 3GPP and ETSI document
+
+Rejected. Service, exposure, and evaluation documents are not acquisition profiles. Draft versions also move more quickly than the measurement contract.
+
+### Add standards fields to native `FieldEvent`
+
+Rejected for now. This would put external interoperability metadata into the core sensing wire model and create unnecessary migration pressure.
+
+### Free form metadata map on each envelope
+
+Rejected. It is difficult to bound, validate, fuzz, and reason about security properties of arbitrary keys and values. It would also weaken deterministic semantics.
+
+### Add a typed, bounded `StandardsReference` list to interop envelopes
+
+Selected. Acquisition provenance remains in `SourceProfile`; other standards relationships are expressed separately and explicitly.
+
+## Prior art and standards
+
+* IEEE 802.11bf 2025 WLAN sensing is already represented by an acquisition source identifier under ADR 268.
+* Bluetooth Core 6.0 Channel Sounding is already represented by an acquisition source identifier under ADR 268.
+* 3GPP TS 23.138 Release 20 draft describes use of sensing results for vertical applications.
+* 3GPP TS 29.545 Release 20 draft describes Sensing Function Services Stage 3.
+* ETSI GR ISC 009 addresses demonstrability, adoption, evaluation, and use of existing infrastructure for ISAC.
+* ETSI GR ISC 003 separates sensing service control, measurement coordination, processing, storage, and result exposure in its architecture.
+
+The referenced drafts are inputs to interoperability design, not normative claims by RuField.
+
+## Decision
+
+Add a typed `StandardsReference` to `rufield-interop` with:
+
+* organization
+* document identifier
+* exact version
+* optional release or stage
+* reference date
+* architectural role
+* `compliance_claim`, which must remain false
+
+Add optional lists to `CloudEvent` and `SosaObservation`. Both lists use `serde(default)` plus `skip_serializing_if = Vec::is_empty`, so old serialized outputs remain byte identical when no reference is present.
+
+Add `to_cloud_event_with_references` and `to_sosa_observation_with_references` rather than changing the existing constructors.
+
+## Architecture
+
+```text
+native FieldEvent
+      |
+      | acquisition provenance
+      v
+SourceProfile
+      |
+      +--------------------------+
+      |                          |
+      v                          v
+CloudEvents 1.0             SOSA JSON LD
+      |                          |
+      +---- StandardsReference --+
+              metadata only
+```
+
+`StandardsReference` is not part of `FieldEvent` and cannot modify tensor, observation, privacy, calibration, or provenance state.
+
+## Interfaces
+
+`StandardsReference::new` validates a reference before it can be emitted through the explicit constructors.
+
+Inbound CloudEvents and SOSA projections validate every attached reference before returning the native event.
+
+The implementation bounds the list to 16 references, document identifiers to 96 bytes, versions to 32 bytes, and release or stage descriptions to 48 bytes. It rejects empty strings, leading or trailing whitespace, control characters, malformed dates, and any `compliance_claim = true`.
+
+## Data flow
+
+1. A sensing adapter produces a native `FieldEvent` under its actual acquisition profile.
+2. An integration chooses zero or more external standards references relevant to its service or exposure behavior.
+3. `rufield-interop` validates the bounded references.
+4. The typed references are serialized alongside the unchanged native event.
+5. An inbound envelope is rejected if a reference violates bounds or asserts compliance.
+6. A valid envelope returns the unchanged native `FieldEvent`.
+
+## Security considerations
+
+External standards metadata is attacker controlled at trust boundaries.
+
+The implementation therefore:
+
+* bounds list size and string length before accepting the metadata semantically
+* rejects control characters that could corrupt logs or downstream text protocols
+* rejects unknown enum values through Serde
+* rejects malformed date shapes
+* refuses compliance claims on both emit and ingest paths
+* preserves native event provenance independently of the reference metadata
+
+Future signed interop envelopes should include standards references in the signed bytes. This ADR does not introduce a new signature layer.
+
+## Privacy considerations
+
+A standards reference contains no sensor payload, identity, location, or biometric data by design. It does not lower the privacy class of the enclosed event. Existing RuField privacy authorization applies to the native payload independently.
+
+## Performance implications
+
+The no reference path adds an empty `Vec` field in memory but emits no additional wire bytes because it is omitted by Serde. The referenced path adds bounded validation linear in at most 16 references and wire bytes proportional to explicitly supplied metadata.
+
+A measured release benchmark is still required before any latency number is claimed.
+
+## Hardware implications
+
+None. This change is confined to the Rust interoperability layer.
+
+## Compatibility
+
+Backward compatible at the serialized fixture level when no references are attached. Existing constructors and `SourceProfile` identifiers are unchanged.
+
+The Rust public `CloudEvent` and `SosaObservation` structs gain additive fields, so downstream code using exhaustive struct literals may need to add the new field. This is a source compatibility consideration and must be called out in the PR.
+
+## Migration
+
+No stored native event migration is required.
+
+Applications deserializing old interop envelopes receive an empty reference list through `serde(default)`. New envelopes without references remain byte identical to old golden fixtures.
+
+## Alternatives rejected
+
+* moving draft identifiers into the acquisition profile
+* changing the native RuField wire version
+* adding arbitrary metadata maps
+* introducing a dedicated 3GPP or ETSI protocol dependency before a concrete protocol implementation exists
+
+## Risks
+
+* Consumers may still visually interpret a standards reference as compliance despite the typed invariant. Documentation and UI must use wording such as `reference`, not `compliant`.
+* A future standards document may require fields not represented here. Add typed roles or fields only when concrete interoperability work demands them.
+* Calendar date validation is intentionally structural and bounds month and day but is not a full Gregorian calendar implementation. It introduces no date parsing dependency.
+
+## Open questions
+
+* Should a future signed CloudEvent wrapper bind the reference list into an external detached signature in addition to the native event receipt?
+* Should finalized standards versions receive convenience constructors after their semantics stabilize?
+* Is a separate service profile projection needed once TS 29.545 interfaces mature beyond draft status?
+
+## Benchmark plan
+
+Against current main:
+
+* serialize the existing CloudEvent and SOSA golden fixtures and require byte equality
+* serialize and deserialize envelopes with one, three, and sixteen standards references
+* report encoded byte delta
+* run at least three release benchmark repetitions for encode and decode latency
+* fuzz malformed external JSON where the repository fuzz infrastructure permits
+
+No performance improvement is claimed by this ADR. The success condition is bounded interoperability metadata with no measurable regression on the default path.
+
+## Acceptance criteria
+
+* Existing no reference golden fixtures remain byte identical.
+* TS 23.138 0.2.0, TS 29.545 0.2.0, and ETSI GR ISC 009 0.0.3 can be represented as metadata.
+* `compliance_claim = true` is rejected.
+* Oversized and control character inputs are rejected.
+* More than 16 references are rejected.
+* Native `FieldEvent` round trips unchanged.
+* Workspace tests, fmt, and clippy pass.
+* PR documents the exact source compatibility effect of the two additive struct fields.
+
+## Rollback strategy
+
+Remove the optional reference fields and explicit reference constructors. Native events and acquisition profiles require no rollback or migration.
+
+## References
+
+* https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=5529
+* https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=5533
+* https://portal.etsi.org/Portal_WI/Form1.asp?NbToDisplay=30&PersonId=0&SubTB=&SupCrit=F5G+++++++++++++++++++++++4678284&TabId=&TbId=0&WIcritID=18
+* ETSI GR ISC 003, Integrated Sensing And Communications, System and RAN Architectures
+* ADR 268, Standards Projections


### PR DESCRIPTION
## Problem

RuField distinguishes acquisition provenance through `SourceProfile`, but 3GPP and ETSI ISAC service and evaluation documents advance independently of radio acquisition formats. Treating those documents as acquisition profiles would conflate measurement provenance with service, exposure, evaluation, security, or compute guidance and could be misread as compliance.

Closes #14.

## Research and standards basis

Initial implementation responded to:

* 3GPP TS 23.138 `Use of sensing results for Vertical Applications`, 0.2.0 uploaded 2026-09-02.
* 3GPP TS 29.545 `Sensing Function Services; Stage 3`, 0.2.0 uploaded 2026-09-04.
* ETSI GR ISC 009 `Demonstrability, Adoption, and Technology Evolution for ISAC`, early draft 0.0.3 dated 2026-09-02.

Freshness review on 2026-09-14 found the official 3GPP portal now lists TS 23.138 version 1.0.0 for SA#113 uploaded 2026-09-08 while the specification remains marked Draft for Release 20. This PR now includes a regression test for that exact reference and preserves the rule that a numeric version cannot manufacture finality, certification, trust, or compliance.

The identifiers are references only. This PR does not implement 3GPP, ETSI, IEEE, Bluetooth, or a certification profile.

## Architecture

ADR 271 keeps three concepts separate:

1. `SourceProfile` describes how a normalized measurement was acquired.
2. `StandardsReference` records which external document informed an interoperability, service, exposure, evaluation, security, or compute layer.
3. Native `FieldEvent` provenance and trust state remain authoritative and unchanged.

## Implementation

`rufield-interop` adds:

* `StandardsOrganization`
* `StandardsRole`
* bounded `StandardsReference`
* optional CloudEvents `standardsreferences`
* optional SOSA `rufield:standardsReferences`
* `to_cloud_event_with_references`
* `to_sosa_observation_with_references`
* inbound validation on both projection paths

Bounds:

* at most 16 references per envelope
* document identifier at most 96 bytes
* version at most 32 bytes
* release or stage at most 48 bytes
* structural YYYY-MM-DD date validation
* control character and surrounding whitespace rejection
* `compliance_claim = true` always rejected

Fresh regression coverage in `crates/rufield-interop/tests/standards_watch_2026_09_14.rs` verifies that TS 23.138 1.0.0 at SA#113 is representable as `Release 20 draft; SA#113` and that the same reference still fails validation if `compliance_claim` is changed to true.

## Backward compatibility

The existing constructors emit empty reference lists and use `skip_serializing_if = Vec::is_empty`. Existing CloudEvents and SOSA golden fixtures prove byte identity on the no reference path.

Native RuField wire semantics and `SourceProfile` identifiers do not change.

Source compatibility note: public `CloudEvent` and `SosaObservation` structs gain additive fields, so downstream exhaustive Rust struct literals need to supply the new field. Existing serialized envelopes deserialize through `serde(default)`.

## Security review

External standards metadata is untrusted.

Controls include bounded list size, bounded strings, control character rejection, enum constrained organizations and roles, malformed date rejection, and a fail closed prohibition on compliance claims. Standards metadata cannot alter native tensor, observation, privacy, calibration, provenance, authorization, or trust state.

The 2026-09-14 review adds an explicit invariant: standards version numbers are factual metadata and never imply maturity or compliance.

No new dependency or unsafe Rust is introduced.

## Testing

Previously passing exact head `689a93bd752cb17735b1322f50bc260fb262d9a9` completed:

* `cargo build --workspace --all-targets`
* `cargo test --workspace`
* `cargo clippy --workspace -- -W clippy::all`
* `cargo run -p rufield-bench -- 2026`

The updated head adds the TS 23.138 SA#113 regression tests and refreshed ADR. CI for the updated exact head must complete successfully before this draft can be promoted.

## Benchmarks

No performance improvement is claimed. The no reference wire path adds zero serialized bytes because the empty field is omitted. A focused release encode and decode microbenchmark remains required before promotion from draft, as specified by ADR 271 and issue #14.

## MetaHarness status

Latest stable GitHub release checked during the 2026-09-14 cycle is `metaharness` v0.4.4. The connected automation execution container cannot resolve public package hosts or materialize the repo from GitHub, so no local `npx metaharness@0.4.4` result is claimed. Repository specific MetaHarness validation remains a promotion gate rather than being replaced by fabricated evidence.

## Known limitations

* standards metadata is not standards compliance
* TS 23.138 is still marked Draft on the official portal even though SA#113 lists version 1.0.0
* Gregorian date validation is structural rather than a full calendar library
* signed external envelopes should eventually bind the standards reference list if an external signature layer is added

## Rollback

Remove the optional reference fields, explicit reference constructors, and the standards watch integration test. Native `FieldEvent` and source profiles require no migration.

## ADR

`docs/ADR-271-isac-standards-references.md`

## Coordination

Weekly cross repository promotion evidence is recorded in `ruvnet/core-memory#95`.